### PR TITLE
fix: migrate from Terraform to OpenTofu to remove geo-block dependency

### DIFF
--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -128,22 +128,22 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
         with:
-          terraform_version: 1.6.0
+          tofu_version: 1.9.0
 
-      - name: Terraform Init
+      - name: OpenTofu Init
         working-directory: infra/gcp
-        run: terraform init
+        run: tofu init
 
-      - name: Terraform Plan
+      - name: OpenTofu Plan
         working-directory: infra/gcp
-        run: terraform plan -out=tfplan
+        run: tofu plan -out=tfplan
 
-      - name: Terraform Apply
+      - name: OpenTofu Apply
         working-directory: infra/gcp
-        run: terraform apply -auto-approve tfplan
+        run: tofu apply -auto-approve tfplan
 
   deploy-cloudrun:
     name: Deploy Cloud Run Service

--- a/infra/gcp/.terraform.lock.hcl
+++ b/infra/gcp/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:0RjrEaRJMIWbgQ4sBfjjLOy9tZiaKaq4r5J1iVz085E=",
+    "zh:0931f08e81f220ae3132169cfa4ed8e9d8d2045f29ca914afd8ee9e3e9cf56e0",
+    "zh:31afa45a4c8a0fd4abff564ecff8b69a97ac1813ead61c12f5f0bf5d33cec7f1",
+    "zh:536979e437aad59ba41465c9398d8e3d7d3702bfe2a51d80571862d48c817959",
+    "zh:748e14614be32350ece4e9249e09bc1d20e54421983734ded3a0df6d6674ea71",
+    "zh:7c8fe641666603aad6693207c8eaac679b9be15246d77090c73a1a84326d6084",
+    "zh:8095a513a0662323d99c25466b5a291c80b2b0c1857c7c7a7b1159f25dbe4439",
+    "zh:9453db86d14611cab26dba30daf56d1cfef929918207e9e3e78b58299fc8c4fe",
+    "zh:adaa5df5d40060409b6b66136c0ac37b99fb35ac2cf554c584649c236a18d95b",
+    "zh:af2f659b4bd1f44e578f203830bdab829b5e635fcf2a59ffa7e997c16e6611ad",
+    "zh:b75184fe5c162821b0524fa941d6a934c452e815d82e62675bb21bbdc9046dfc",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:KkOlqypKHYYvfzrqVPdhfiyHwYeafFy0WD805a01eSg=",
+    "zh:2df6e40591ceee7ee77d429ea072c9d51fef2dd04015b2604ff332a2af4ac819",
+    "zh:4096af21991ba76ab81c8cb00c0eb0bd4f22619f7e491d60023fb10b8b33bfb1",
+    "zh:44ded286956fff5668f1acbf152b62ca8e6a03abc8df12c5c181bc2ca05b4df7",
+    "zh:7ae19e1b53a0e26bea0acb9a96b4b44038d7c182c3fdd496148fd20e40aa78e1",
+    "zh:81c9812823b78fd1b12bc0acd6dae35bc573944950e09eaf237b2e83b6b587d7",
+    "zh:9db6101421b53b9533807928c651e779f5b8129f4a57ff892bf256c84ba6ed29",
+    "zh:b779729cb08829f621a718ecdfdb503c310ef5411e694996c7cfda7227221134",
+    "zh:c43edb31aee354317a6181272a961965b93722fd18637f38c395af013aa65617",
+    "zh:dbb93970a85f2fe84f650b6a4da694ecb1023a99c3b9bbf6953dccd074fa49ce",
+    "zh:df9d13853269e98651d495571b4d58c883b4386247d0b9c5495c2e82ef721f45",
+  ]
+}

--- a/scripts/deploy_gcp.sh
+++ b/scripts/deploy_gcp.sh
@@ -51,8 +51,8 @@ if ! command -v gcloud &> /dev/null; then
     exit 1
 fi
 
-if ! command -v terraform &> /dev/null; then
-    print_error "Terraform is not installed"
+if ! command -v tofu &> /dev/null; then
+    print_error "OpenTofu is not installed"
     exit 1
 fi
 
@@ -97,22 +97,22 @@ echo ""
 # Deploy infrastructure
 print_header "2/4 - Deploying Infrastructure"
 cd "$PROJECT_ROOT/infra/gcp"
-print_info "Initializing Terraform..."
+print_info "Initializing OpenTofu..."
 if [ -n "$TF_HTTP_ADDRESS" ]; then
     print_info "Using HTTP backend (TF_HTTP_ADDRESS is set)"
-    terraform init
+    tofu init
 else
-    print_warning "TF_HTTP_ADDRESS is not set; using local Terraform state for this deployment"
-    terraform init -backend=false
+    print_warning "TF_HTTP_ADDRESS is not set; using local OpenTofu state for this deployment"
+    tofu init -backend=false
 fi
 
-print_info "Applying Terraform configuration..."
-terraform apply -auto-approve
+print_info "Applying OpenTofu configuration..."
+tofu apply -auto-approve
 
 # Get outputs
-CLOUDRUN_URL=$(terraform output -raw cloudrun_url)
-FIREBASE_WEB_API_KEY=$(terraform output -raw firebase_web_api_key)
-FIREBASE_AUTH_DOMAIN=$(terraform output -raw firebase_auth_domain)
+CLOUDRUN_URL=$(tofu output -raw cloudrun_url)
+FIREBASE_WEB_API_KEY=$(tofu output -raw firebase_web_api_key)
+FIREBASE_AUTH_DOMAIN=$(tofu output -raw firebase_auth_domain)
 print_info "Infrastructure deployed successfully"
 echo ""
 


### PR DESCRIPTION
Closes #3

## What changed

- Updated `scripts/deploy_gcp.sh` — replaced `terraform` commands with `tofu`
- Updated `.github/workflows/gcp-deploy.yml` — replaced terraform binary with tofu
- Ran `tofu init` in `infra/gcp/` — lock file updated to `registry.opentofu.org` provider URLs
- `tofu validate` passes: configuration is valid

## Why

HashiCorp's Terraform registry (`registry.terraform.io`) is geo-blocked in Lebanon, requiring a VPN to deploy. OpenTofu uses `registry.opentofu.org` which has no geo-restrictions.

## Notes

- No `.tf` files were modified — OpenTofu is 100% HCL compatible
- State files are unchanged