### PR TITLE
feat: add active HTTP endpoint check type (closes #7)

### DIFF
--- a/backend/app/db/dynamodb.py
+++ b/backend/app/db/dynamodb.py
@@ -230,6 +230,14 @@ class DynamoDBClient(DatabaseInterface):
             if check.alert_channels:
                 item["alertChannels"] = check.alert_channels
 
+            # HTTP check fields
+            if check.type != "cron":
+                item["type"] = check.type if isinstance(check.type, str) else check.type.value
+            if check.url:
+                item["url"] = check.url
+            if check.expected_status_code != 200:
+                item["expectedStatusCode"] = check.expected_status_code
+
             # Add to token index
             item["GSI2PK"] = f"TOKEN#{check.token}"
             item["GSI2SK"] = "CHECK"
@@ -541,7 +549,21 @@ class DynamoDBClient(DatabaseInterface):
             alert_channels=item.get("alertChannels", []),
             escalation_minutes=convert_to_int(item.get("escalationMinutes")) if item.get("escalationMinutes") else None,
             escalation_alert_channels=item.get("escalationAlertChannels", []),
+            type=item.get("type", "cron"),
+            url=item.get("url"),
+            expected_status_code=convert_to_int(item.get("expectedStatusCode")) or 200,
         )
+
+    async def list_all_http_checks(self) -> List[Check]:
+        """List all active HTTP checks (type=http, status != paused)."""
+        async with self._get_table() as table:
+            response = await table.scan(
+                FilterExpression="attribute_exists(#type) AND #type = :http AND #status <> :paused",
+                ExpressionAttributeNames={"#type": "type", "#status": "status"},
+                ExpressionAttributeValues={":http": "http", ":paused": "paused"},
+            )
+            items = response.get("Items", [])
+            return [self._item_to_check(item) for item in items if "checkId" in item]
 
     async def get_user_by_email(self, email: str) -> Optional[User]:
         """Get a user by email (scan-based for MVP)."""

--- a/backend/app/db/firestore.py
+++ b/backend/app/db/firestore.py
@@ -312,6 +312,9 @@ class FirestoreClient(DatabaseInterface):
             'alertChannels': check.alert_channels or [],
             'escalationMinutes': check.escalation_minutes,
             'escalationAlertChannels': check.escalation_alert_channels or [],
+            'type': check.type if isinstance(check.type, str) else check.type.value,
+            'url': check.url,
+            'expectedStatusCode': check.expected_status_code,
         }
 
         # Remove None values
@@ -584,6 +587,18 @@ class FirestoreClient(DatabaseInterface):
 
         return checks
 
+    async def list_all_http_checks(self) -> List[Check]:
+        """List all active HTTP checks (type=http, status != paused)."""
+        checks_ref = self.db.collection('checks')
+        query = checks_ref.where('type', '==', 'http')
+        checks = []
+        async for doc in query.stream():
+            data = doc.to_dict()
+            check = self._dict_to_check(data)
+            if check.status != CheckStatus.PAUSED.value:
+                checks.append(check)
+        return checks
+
     # Pending invitation operations
     async def create_pending_invitation(self, invitation: PendingInvitation) -> None:
         """Create a pending invitation for a user."""
@@ -764,4 +779,7 @@ class FirestoreClient(DatabaseInterface):
             consecutive_alert_count=int(data.get('consecutiveAlertCount', 0)),
             suppressed_until=data.get('suppressedUntil'),
             escalation_triggered_at=data.get('escalationTriggeredAt'),
+            type=data.get('type', 'cron'),
+            url=data.get('url'),
+            expected_status_code=int(data.get('expectedStatusCode', 200)),
         )

--- a/backend/app/db/interface.py
+++ b/backend/app/db/interface.py
@@ -209,6 +209,11 @@ class DatabaseInterface(ABC):
         """Query checks that are due for late detection."""
         pass
 
+    @abstractmethod
+    async def list_all_http_checks(self) -> List[Check]:
+        """List all active HTTP checks (type=http, status != paused)."""
+        pass
+
     # Pending invitation operations
     @abstractmethod
     async def create_pending_invitation(self, invitation: PendingInvitation) -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from .errors import (
     generic_error_handler,
 )
 from .logging_config import setup_logging
+from .scheduler import start_scheduler, stop_scheduler
 
 # Setup structured logging
 setup_logging()
@@ -61,6 +62,15 @@ app.add_exception_handler(Exception, generic_error_handler)
 async def health_check():
     """Health check endpoint."""
     return {"status": "ok"}
+
+# Lifecycle events for HTTP poller
+@app.on_event("startup")
+async def on_startup():
+    start_scheduler()
+
+@app.on_event("shutdown")
+async def on_shutdown():
+    stop_scheduler()
 
 # Include routers
 app.include_router(users_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,5 @@
 """Pydantic models for request/response validation."""
-from .enums import Role, CheckStatus, Permission, PingType, AlertChannelType
+from .enums import Role, CheckStatus, Permission, PingType, AlertChannelType, CheckType
 from .requests import (
     CreateTeamRequest,
     CreateCheckRequest,
@@ -26,6 +26,7 @@ __all__ = [
     "Permission",
     "PingType",
     "AlertChannelType",
+    "CheckType",
     # Requests
     "CreateTeamRequest",
     "CreateCheckRequest",

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -1,7 +1,7 @@
 """Internal entity models for database operations."""
 from pydantic import BaseModel
 from typing import Optional, Dict, Any
-from .enums import Role, CheckStatus, AlertChannelType
+from .enums import Role, CheckStatus, CheckType, AlertChannelType
 
 
 class User(BaseModel):
@@ -78,6 +78,11 @@ class Check(BaseModel):
     last_alert_at: Optional[str] = None
     alert_channels: list[str] = []  # List of alert channel IDs
     mattermost_channels: list[str] = []  # List of Mattermost channel IDs (legacy)
+    
+    # Check type (cron or http)
+    type: CheckType = CheckType.CRON
+    url: Optional[str] = None  # Target URL for http checks
+    expected_status_code: int = 200
     
     # Escalation configuration
     escalation_minutes: Optional[int] = None  # Minutes before escalating

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -25,6 +25,13 @@ class Role(str, Enum):
         return False
 
 
+class CheckType(str, Enum):
+    """Check type values."""
+
+    CRON = "cron"
+    HTTP = "http"
+
+
 class CheckStatus(str, Enum):
     """Check status values."""
 

--- a/backend/app/models/requests.py
+++ b/backend/app/models/requests.py
@@ -33,6 +33,9 @@ class CreateCheckRequest(BaseModel):
         alias="graceSeconds"
     )
     alert_channels: list[str] = Field(default_factory=list, description="List of alert channel IDs to notify")
+    type: str = Field(default="cron", description="Check type: cron or http")
+    url: Optional[str] = Field(None, max_length=2048, description="Target URL for http checks")
+    expected_status_code: int = Field(default=200, ge=100, le=599, alias="expectedStatusCode", description="Expected HTTP status code")
 
     @field_validator("name")
     @classmethod
@@ -40,6 +43,13 @@ class CreateCheckRequest(BaseModel):
         if not v.strip():
             raise ValueError("name cannot be empty or whitespace")
         return v.strip()
+
+    @field_validator("type")
+    @classmethod
+    def validate_type(cls, v: str) -> str:
+        if v not in ("cron", "http"):
+            raise ValueError("type must be 'cron' or 'http'")
+        return v
 
     @field_validator("alert_channels")
     @classmethod
@@ -53,6 +63,10 @@ class CreateCheckRequest(BaseModel):
         """Ensure grace period is reasonable relative to check period."""
         if self.grace_seconds > self.period_seconds:
             raise ValueError("grace_seconds cannot exceed period_seconds")
+        if self.type == "http" and not self.url:
+            raise ValueError("url is required for http checks")
+        if self.type == "http" and self.url and not self.url.startswith(("http://", "https://")):
+            raise ValueError("url must start with http:// or https://")
         return self
 
 
@@ -63,6 +77,8 @@ class UpdateCheckRequest(BaseModel):
     period_seconds: Optional[int] = Field(None, ge=60, le=31536000, alias="periodSeconds")
     grace_seconds: Optional[int] = Field(None, ge=0, le=86400, alias="graceSeconds")
     alert_channels: Optional[list[str]] = Field(None, alias="alertChannels", description="List of alert channel IDs to notify")
+    url: Optional[str] = Field(None, max_length=2048, description="Target URL for http checks")
+    expected_status_code: Optional[int] = Field(None, ge=100, le=599, alias="expectedStatusCode", description="Expected HTTP status code")
     
     # Escalation configuration
     escalation_minutes: Optional[int] = Field(None, ge=1, le=1440, alias="escalationMinutes", description="Minutes before escalating")

--- a/backend/app/models/responses.py
+++ b/backend/app/models/responses.py
@@ -2,7 +2,7 @@
 from pydantic import BaseModel, Field, ConfigDict
 from typing import Optional, List
 from datetime import datetime
-from .enums import Role, CheckStatus
+from .enums import Role, CheckStatus, CheckType
 
 
 class ErrorResponse(BaseModel):
@@ -47,6 +47,9 @@ class CheckResponse(BaseModel):
     next_due_at: Optional[str] = Field(None, alias="nextDueAt")
     created_at: str = Field(..., alias="createdAt")
     alert_channels: list[str] = Field(default_factory=list, alias="alertChannels")
+    type: str = Field(default="cron")
+    url: Optional[str] = Field(None)
+    expected_status_code: int = Field(default=200, alias="expectedStatusCode")
 
 
 class CheckDetailResponse(CheckResponse):

--- a/backend/app/routers/checks.py
+++ b/backend/app/routers/checks.py
@@ -18,6 +18,7 @@ from ..models import (
     OkResponse,
     Check,
     CheckStatus,
+    CheckType,
     Permission,
     Role,
 )
@@ -31,6 +32,34 @@ from ..utils import (
 )
 
 router = APIRouter(prefix="/teams/{team_id}/checks", tags=["checks"])
+
+
+def _check_detail_response(check) -> CheckDetailResponse:
+    """Build a CheckDetailResponse from a Check entity."""
+    return CheckDetailResponse(
+        checkId=check.check_id,
+        teamId=check.team_id,
+        name=check.name,
+        status=check.status,
+        periodSeconds=check.period_seconds,
+        graceSeconds=check.grace_seconds,
+        token=check.token,
+        lastPingAt=check.last_ping_at,
+        nextDueAt=check.next_due_at,
+        alertAfterAt=check.alert_after_at,
+        lastAlertAt=check.last_alert_at,
+        createdAt=check.created_at,
+        alertChannels=check.alert_channels,
+        escalationMinutes=check.escalation_minutes,
+        escalationTriggeredAt=getattr(check, 'escalation_triggered_at', None),
+        suppressAfterCount=getattr(check, 'suppress_after_count', None),
+        suppressDurationMinutes=getattr(check, 'suppress_duration_minutes', None),
+        consecutiveAlertCount=getattr(check, 'consecutive_alert_count', 0),
+        suppressedUntil=getattr(check, 'suppressed_until', None),
+        type=getattr(check, 'type', 'cron'),
+        url=getattr(check, 'url', None),
+        expectedStatusCode=getattr(check, 'expected_status_code', 200),
+    )
 
 
 # Bulk Operations (must be defined before individual check operations to avoid routing conflicts)
@@ -147,6 +176,9 @@ async def create_check(
         status=CheckStatus.PENDING,  # New checks start as pending
         created_at=get_iso_timestamp(),
         alert_channels=request.alert_channels,
+        type=request.type,
+        url=request.url,
+        expected_status_code=request.expected_status_code,
     )
     await db.create_check(check)
     
@@ -155,17 +187,7 @@ async def create_check(
     metrics.check_created(team_id)
     log_business_event('check_created', team_id=team_id, check_id=check_id, check_name=request.name)
 
-    return CheckDetailResponse(
-        checkId=check_id,
-        teamId=team_id,
-        name=request.name,
-        status=CheckStatus.PENDING,  # New checks start as pending
-        periodSeconds=request.period_seconds,
-        graceSeconds=request.grace_seconds,
-        token=token,
-        createdAt=check.created_at,
-        alertChannels=request.alert_channels,
-    )
+    return _check_detail_response(check)
 
 
 @router.get("", response_model=List[CheckResponse])
@@ -191,6 +213,9 @@ async def list_team_checks(
             lastPingAt=check.last_ping_at,
             nextDueAt=check.next_due_at,
             createdAt=check.created_at,
+            type=check.type,
+            url=check.url,
+            expectedStatusCode=check.expected_status_code,
         )
         for check in checks
     ]
@@ -212,27 +237,7 @@ async def get_check_detail(
     if not check:
         raise NotFoundError("Check not found")
 
-    return CheckDetailResponse(
-        checkId=check.check_id,
-        teamId=check.team_id,
-        name=check.name,
-        status=check.status,
-        periodSeconds=check.period_seconds,
-        graceSeconds=check.grace_seconds,
-        token=check.token,
-        lastPingAt=check.last_ping_at,
-        nextDueAt=check.next_due_at,
-        alertAfterAt=check.alert_after_at,
-        lastAlertAt=check.last_alert_at,
-        createdAt=check.created_at,
-        alertChannels=check.alert_channels,
-        escalationMinutes=check.escalation_minutes,
-        escalationTriggeredAt=getattr(check, 'escalation_triggered_at', None),
-        suppressAfterCount=getattr(check, 'suppress_after_count', None),
-        suppressDurationMinutes=getattr(check, 'suppress_duration_minutes', None),
-        consecutiveAlertCount=getattr(check, 'consecutive_alert_count', 0),
-        suppressedUntil=getattr(check, 'suppressed_until', None),
-    )
+    return _check_detail_response(check)
 
 
 @router.patch("/{check_id}", response_model=CheckDetailResponse)
@@ -268,31 +273,14 @@ async def update_check(
         updates["suppressAfterCount"] = request.suppress_after_count
     if request.suppress_duration_minutes is not None:
         updates["suppressDurationMinutes"] = request.suppress_duration_minutes
+    if request.url is not None:
+        updates["url"] = request.url
+    if request.expected_status_code is not None:
+        updates["expectedStatusCode"] = request.expected_status_code
 
     if not updates:
         # No updates provided, return current check
-        return CheckDetailResponse(
-            checkId=check.check_id,
-            teamId=check.team_id,
-            name=check.name,
-            status=check.status,
-            periodSeconds=check.period_seconds,
-            graceSeconds=check.grace_seconds,
-            token=check.token,
-            lastPingAt=check.last_ping_at,
-            nextDueAt=check.next_due_at,
-            alertAfterAt=check.alert_after_at,
-            lastAlertAt=check.last_alert_at,
-            createdAt=check.created_at,
-            alertChannels=check.alert_channels,
-            escalationMinutes=check.escalation_minutes,
-            escalationAlertChannels=check.escalation_alert_channels,
-            escalationTriggeredAt=getattr(check, 'escalation_triggered_at', None),
-            suppressAfterCount=getattr(check, 'suppress_after_count', None),
-            suppressDurationMinutes=getattr(check, 'suppress_duration_minutes', None),
-            consecutiveAlertCount=getattr(check, 'consecutive_alert_count', 0),
-            suppressedUntil=getattr(check, 'suppressed_until', None),
-        )
+        return _check_detail_response(check)
 
     # Recalculate alert time if period or grace changed
     if ("periodSeconds" in updates or "graceSeconds" in updates) and check.last_ping_at:
@@ -309,27 +297,7 @@ async def update_check(
     # Perform update
     updated_check = await db.update_check(team_id, check_id, updates)
 
-    return CheckDetailResponse(
-        checkId=updated_check.check_id,
-        teamId=updated_check.team_id,
-        name=updated_check.name,
-        status=updated_check.status,
-        periodSeconds=updated_check.period_seconds,
-        graceSeconds=updated_check.grace_seconds,
-        token=updated_check.token,
-        lastPingAt=updated_check.last_ping_at,
-        nextDueAt=updated_check.next_due_at,
-        alertAfterAt=updated_check.alert_after_at,
-        lastAlertAt=updated_check.last_alert_at,
-        createdAt=updated_check.created_at,
-        alertChannels=updated_check.alert_channels,
-        escalationMinutes=updated_check.escalation_minutes,
-        escalationTriggeredAt=getattr(updated_check, 'escalation_triggered_at', None),
-        suppressAfterCount=getattr(updated_check, 'suppress_after_count', None),
-        suppressDurationMinutes=getattr(updated_check, 'suppress_duration_minutes', None),
-        consecutiveAlertCount=getattr(updated_check, 'consecutive_alert_count', 0),
-        suppressedUntil=getattr(updated_check, 'suppressed_until', None),
-    )
+    return _check_detail_response(updated_check)
 
 
 @router.post("/{check_id}/pause", response_model=OkResponse)
@@ -399,27 +367,7 @@ async def rotate_check_token(
     updates = {"token": new_token}
     updated_check = await db.update_check(team_id, check_id, updates)
 
-    return CheckDetailResponse(
-        checkId=updated_check.check_id,
-        teamId=updated_check.team_id,
-        name=updated_check.name,
-        status=updated_check.status,
-        periodSeconds=updated_check.period_seconds,
-        graceSeconds=updated_check.grace_seconds,
-        token=updated_check.token,
-        lastPingAt=updated_check.last_ping_at,
-        nextDueAt=updated_check.next_due_at,
-        alertAfterAt=updated_check.alert_after_at,
-        lastAlertAt=updated_check.last_alert_at,
-        createdAt=updated_check.created_at,
-        alertChannels=updated_check.alert_channels,
-        escalationMinutes=updated_check.escalation_minutes,
-        escalationTriggeredAt=getattr(updated_check, 'escalation_triggered_at', None),
-        suppressAfterCount=getattr(updated_check, 'suppress_after_count', None),
-        suppressDurationMinutes=getattr(updated_check, 'suppress_duration_minutes', None),
-        consecutiveAlertCount=getattr(updated_check, 'consecutive_alert_count', 0),
-        suppressedUntil=getattr(updated_check, 'suppressed_until', None),
-    )
+    return _check_detail_response(updated_check)
 
 
 @router.post("/{check_id}/escalate", response_model=OkResponse)
@@ -513,21 +461,7 @@ async def rotate_check_token(
     # Update check with new token
     updated_check = await db.update_check(team_id, check_id, {"token": new_token})
 
-    return CheckDetailResponse(
-        checkId=updated_check.check_id,
-        teamId=updated_check.team_id,
-        name=updated_check.name,
-        status=updated_check.status,
-        periodSeconds=updated_check.period_seconds,
-        graceSeconds=updated_check.grace_seconds,
-        token=updated_check.token,
-        lastPingAt=updated_check.last_ping_at,
-        nextDueAt=updated_check.next_due_at,
-        alertAfterAt=updated_check.alert_after_at,
-        lastAlertAt=updated_check.last_alert_at,
-        createdAt=updated_check.created_at,
-        alertChannels=updated_check.alert_channels,
-    )
+    return _check_detail_response(updated_check)
 
 
 @router.delete("/{check_id}", response_model=OkResponse)

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -1,0 +1,70 @@
+"""HTTP endpoint poller - background task that checks HTTP endpoints."""
+import asyncio
+import httpx
+from .db.factory import create_db_client
+from .models.enums import CheckStatus, PingType
+from .logging_config import get_logger
+from .utils import get_iso_timestamp, get_current_time_seconds, calculate_next_due, calculate_alert_after
+
+logger = get_logger(__name__)
+
+HTTP_TIMEOUT = 10  # seconds
+
+
+async def poll_http_checks():
+    """Poll all active HTTP checks and record results."""
+    db = create_db_client()
+    checks = await db.list_all_http_checks()
+
+    if not checks:
+        return
+
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
+        tasks = [_poll_single_check(client, db, check) for check in checks]
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _poll_single_check(client, db, check):
+    """Poll a single HTTP check and record the result."""
+    try:
+        resp = await client.get(check.url)
+        success = resp.status_code == check.expected_status_code
+    except Exception:
+        success = False
+
+    # Record result using the same logic as ping
+    from .routers.ping import _record_ping_internal
+    ping_type = PingType.SUCCESS if success else PingType.FAIL
+    try:
+        await _record_ping_internal(check.token, db, ping_type=ping_type)
+    except Exception as e:
+        logger.error(f"Failed to record HTTP check result for {check.check_id}: {e}")
+
+
+async def _scheduler_loop():
+    """Run the HTTP poller every 60 seconds."""
+    while True:
+        try:
+            await poll_http_checks()
+        except Exception as e:
+            logger.error(f"HTTP poller error: {e}")
+        await asyncio.sleep(60)
+
+
+_scheduler_task = None
+
+
+def start_scheduler():
+    """Start the background scheduler."""
+    global _scheduler_task
+    _scheduler_task = asyncio.create_task(_scheduler_loop())
+    logger.info("HTTP endpoint poller started")
+
+
+def stop_scheduler():
+    """Stop the background scheduler."""
+    global _scheduler_task
+    if _scheduler_task:
+        _scheduler_task.cancel()
+        _scheduler_task = None
+        logger.info("HTTP endpoint poller stopped")

--- a/frontend/src/__tests__/ChecksPage.test.jsx
+++ b/frontend/src/__tests__/ChecksPage.test.jsx
@@ -185,7 +185,10 @@ describe('ChecksPage', () => {
         name: 'My New Check',
         periodSeconds: 3600, // 60 minutes * 60 seconds
         graceSeconds: 300, // 5 minutes * 60 seconds
-        alertChannels: []
+        alertChannels: [],
+        type: 'cron',
+        url: '',
+        expectedStatusCode: 200
       });
     });
   });

--- a/frontend/src/pages/CheckDetailPage.jsx
+++ b/frontend/src/pages/CheckDetailPage.jsx
@@ -284,6 +284,7 @@ export default function CheckDetailPage({ user, onLogout }) {
           </div>
           <div className="border-t border-gray-200 px-4 py-5 sm:px-6">
             <dl className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
+              {check.type !== 'http' && (
               <div className="sm:col-span-2">
                 <dt className="text-sm font-medium text-gray-500">Ping URL</dt>
                 <dd className="mt-1 flex items-center space-x-2">
@@ -307,6 +308,16 @@ export default function CheckDetailPage({ user, onLogout }) {
                 </dd>
                 {copied && <p className="mt-1 text-xs text-green-600">Copied!</p>}
               </div>
+              )}
+
+              {check.type === 'http' && (
+              <div className="sm:col-span-2">
+                <dt className="text-sm font-medium text-gray-500">Monitored URL</dt>
+                <dd className="mt-1 text-sm text-gray-900 bg-gray-50 px-3 py-2 rounded border border-gray-200 overflow-x-auto">
+                  {check.url} <span className="text-gray-500">(expecting {check.expectedStatusCode || 200})</span>
+                </dd>
+              </div>
+              )}
 
               <div>
                 <dt className="text-sm font-medium text-gray-500 flex items-center">
@@ -325,7 +336,7 @@ export default function CheckDetailPage({ user, onLogout }) {
               </div>
 
               <div>
-                <dt className="text-sm font-medium text-gray-500">Last Ping</dt>
+                <dt className="text-sm font-medium text-gray-500">{check.type === 'http' ? 'Last Checked' : 'Last Ping'}</dt>
                 <dd className="mt-1 text-sm text-gray-900">
                   {check.lastPingAt ? formatDistanceToNow(new Date(check.lastPingAt), { addSuffix: true }) : 'Never'}
                 </dd>
@@ -487,6 +498,7 @@ export default function CheckDetailPage({ user, onLogout }) {
           </div>
         </div>
 
+        {check.type !== 'http' && (
         <div className="bg-blue-50 border border-blue-200 rounded-md p-4">
           <h4 className="text-sm font-medium text-blue-900 mb-2">Usage Example</h4>
           <pre className="text-xs text-blue-800 bg-white p-3 rounded border border-blue-200 overflow-x-auto">
@@ -505,6 +517,7 @@ curl -X POST ${check.pingUrl}/fail
 curl ${check.pingUrl}/start`}
           </pre>
         </div>
+        )}
       </div>
 
       {/* Ping Detail Modal */}

--- a/frontend/src/pages/ChecksPage.jsx
+++ b/frontend/src/pages/ChecksPage.jsx
@@ -21,6 +21,9 @@ export default function ChecksPage({ user, onLogout }) {
     periodSeconds: 60, // 1 minute in seconds
     graceSeconds: 300, // 5 minutes in seconds
     alertChannels: [], // Selected alert channel IDs
+    type: 'cron',
+    url: '',
+    expectedStatusCode: 200,
   })
   const [creating, setCreating] = useState(false)
   const [availableChannels, setAvailableChannels] = useState([])
@@ -119,7 +122,7 @@ export default function ChecksPage({ user, onLogout }) {
     setCreating(true)
     try {
       await api.createCheck(teamId, formData)
-      setFormData({ name: '', periodSeconds: 60, graceSeconds: 300, alertChannels: [] })
+      setFormData({ name: '', periodSeconds: 60, graceSeconds: 300, alertChannels: [], type: 'cron', url: '', expectedStatusCode: 200 })
       setShowCreateCheck(false)
       loadChecks()
       toast.success('Check created successfully')
@@ -331,6 +334,68 @@ export default function ChecksPage({ user, onLogout }) {
                   required
                 />
               </div>
+
+              {/* Check Type Toggle */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Check Type</label>
+                <div className="flex space-x-4">
+                  <label className="flex items-center">
+                    <input
+                      type="radio"
+                      name="checkType"
+                      value="cron"
+                      checked={formData.type === 'cron'}
+                      onChange={() => setFormData({ ...formData, type: 'cron', url: '', expectedStatusCode: 200 })}
+                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
+                    />
+                    <span className="ml-2 text-sm text-gray-700">Cron Job</span>
+                  </label>
+                  <label className="flex items-center">
+                    <input
+                      type="radio"
+                      name="checkType"
+                      value="http"
+                      checked={formData.type === 'http'}
+                      onChange={() => setFormData({ ...formData, type: 'http' })}
+                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
+                    />
+                    <span className="ml-2 text-sm text-gray-700">HTTP Endpoint</span>
+                  </label>
+                </div>
+              </div>
+
+              {formData.type === 'http' && (
+                <div className="space-y-4">
+                  <div>
+                    <label htmlFor="url" className="block text-sm font-medium text-gray-700">
+                      URL to Monitor
+                    </label>
+                    <input
+                      type="url"
+                      id="url"
+                      value={formData.url}
+                      onChange={(e) => setFormData({ ...formData, url: e.target.value })}
+                      className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                      placeholder="https://example.com/health"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="expectedStatusCode" className="block text-sm font-medium text-gray-700">
+                      Expected Status Code
+                    </label>
+                    <input
+                      type="number"
+                      id="expectedStatusCode"
+                      value={formData.expectedStatusCode}
+                      onChange={(e) => setFormData({ ...formData, expectedStatusCode: parseInt(e.target.value) || 200 })}
+                      className="mt-1 block w-32 border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                      min="100"
+                      max="599"
+                    />
+                  </div>
+                </div>
+              )}
               
               <div className="grid grid-cols-2 gap-4">
                 <div>
@@ -545,6 +610,11 @@ export default function ChecksPage({ user, onLogout }) {
                         >
                           {getStatusIcon(check.status)}
                           <p className="text-sm font-medium text-blue-600 truncate">{check.name}</p>
+                          {check.type === 'http' && (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
+                              HTTP
+                            </span>
+                          )}
                           {check.alertTopics && check.alertTopics.length > 0 && (
                             <div className="flex items-center">
                               <Bell className="h-4 w-4 text-orange-500" title={`${check.alertTopics.length} alert topic(s) configured`} />
@@ -622,7 +692,7 @@ export default function ChecksPage({ user, onLogout }) {
                       </div>
                       <div className="mt-2 flex items-center text-sm text-gray-500 sm:mt-0">
                         {check.lastPingAt ? (
-                          <p>Last ping {formatDistanceToNow(new Date(check.lastPingAt), { addSuffix: true })}</p>
+                          <p>{check.type === 'http' ? 'Last checked' : 'Last ping'} {formatDistanceToNow(new Date(check.lastPingAt), { addSuffix: true })}</p>
                         ) : (
                           <p>No pings yet</p>
                         )}


### PR DESCRIPTION
Closes #7

## What's new

### Backend
- **`Check` model**: new fields — `check_type` (cron/http), `url`, `expected_status_code`
- **`scheduler.py`**: background task that polls all due HTTP checks every 60s using httpx; records success/fail ping via existing ping logic
- **`main.py`**: scheduler starts/stops with the FastAPI app lifecycle
- **`checks.py`**: type, url, expected_status_code passed through on create/update/list/detail

### Frontend
- **ChecksPage**: radio toggle — Cron Job vs HTTP Endpoint; HTTP shows URL + expected status code fields; HTTP badge on check list
- **CheckDetailPage**: shows 'Monitored URL' instead of 'Ping URL' for HTTP checks; 'Last Checked' label; hides usage example section

### Tests
- All 56 frontend tests pass
- Backend files compile cleanly