### PR TITLE
fix: store check types as-is, no cron/heartbeat normalization

### DIFF
--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -29,6 +29,7 @@ class CheckType(str, Enum):
     """Check type values."""
 
     CRON = "cron"
+    HEARTBEAT = "heartbeat"
     HTTP = "http"
 
 

--- a/backend/app/models/requests.py
+++ b/backend/app/models/requests.py
@@ -51,8 +51,7 @@ class CreateCheckRequest(BaseModel):
     def validate_type(cls, v: str) -> str:
         if v not in ("cron", "heartbeat", "http"):
             raise ValueError("type must be 'cron', 'heartbeat', or 'http'")
-        if v == "heartbeat":
-            return "cron"  # heartbeat is alias for cron
+
         return v
 
     @field_validator("alert_channels")

--- a/backend/app/routers/checks.py
+++ b/backend/app/routers/checks.py
@@ -56,7 +56,7 @@ def _check_detail_response(check) -> CheckDetailResponse:
         suppressDurationMinutes=getattr(check, 'suppress_duration_minutes', None),
         consecutiveAlertCount=getattr(check, 'consecutive_alert_count', 0),
         suppressedUntil=getattr(check, 'suppressed_until', None),
-        type='heartbeat' if getattr(check, 'type', 'cron') == 'cron' else getattr(check, 'type', 'cron'),
+        type=getattr(check, 'type', 'cron'),
         url=getattr(check, 'url', None),
         expectedStatusCode=getattr(check, 'expected_status_code', 200),
         expectedString=getattr(check, 'expected_string', None),


### PR DESCRIPTION
heartbeat and cron are distinct types now. Stored and returned as provided. Fixes provider inconsistency when using check_type="cron".