### PR TITLE
fix: parse failureThreshold and other aliases in PATCH requests

### DIFF
--- a/backend/app/models/requests.py
+++ b/backend/app/models/requests.py
@@ -1,5 +1,5 @@
 """Request models for API validation."""
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing import Optional
 import re
 
@@ -75,6 +75,8 @@ class CreateCheckRequest(BaseModel):
 
 class UpdateCheckRequest(BaseModel):
     """Request to update a check."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     name: Optional[str] = Field(None, min_length=1, max_length=200)
     period_seconds: Optional[int] = Field(None, ge=60, le=31536000, alias="periodSeconds")


### PR DESCRIPTION
UpdateCheckRequest was missing model_config with populate_by_name=True, causing aliased fields like failureThreshold to be ignored on PATCH.