### PR TITLE
fix: persist and return failureThreshold from Firestore

### DIFF
--- a/backend/app/db/firestore.py
+++ b/backend/app/db/firestore.py
@@ -778,4 +778,5 @@ class FirestoreClient(DatabaseInterface):
             type=data.get('type', 'cron'),
             url=data.get('url'),
             expected_status_code=int(data.get('expectedStatusCode', 200)),
+            failure_threshold=int(data.get('failureThreshold', 1)),
         )


### PR DESCRIPTION
_dict_to_check was missing failure_threshold, so it always returned 1 regardless of stored value.