### PR TITLE
fix: failureThreshold not persisted to Firestore on create

### DIFF
--- a/backend/app/db/firestore.py
+++ b/backend/app/db/firestore.py
@@ -316,6 +316,7 @@ class FirestoreClient(DatabaseInterface):
             'schedule': check.schedule,
             'url': check.url,
             'expectedStatusCode': check.expected_status_code,
+            'failureThreshold': check.failure_threshold,
         }
 
         # Remove None values


### PR DESCRIPTION
create_check was saving expectedStatusCode but not failureThreshold, so it always read back as the default (1).