### PR TITLE
fix(#35): Re-enable domain allowlist for Google OAuth

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -70,9 +70,9 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
         user_id, email, name, email_verified = extract_user_info(claims)
         print(f"DEBUG: Extracted user info - ID: {user_id}, Email: {email}, Name: {name}")
         
-        # Check domain allowlist - temporarily disabled for debugging
-        # if not check_domain_allowed(email):
-        #     raise ForbiddenError("Email domain not allowed")
+        # Check domain allowlist
+        if not check_domain_allowed(email):
+            raise ForbiddenError("Email domain not allowed")
         
         return CurrentUser(user_id=user_id, email=email, name=name)
         

--- a/backend/tests/test_dependencies.py
+++ b/backend/tests/test_dependencies.py
@@ -64,7 +64,7 @@ class TestGetCurrentUser:
         
         mock_verify_jwt.assert_called_once_with("mock-jwt-token")
         mock_extract_user.assert_called_once_with(mock_jwt_claims)
-        # Domain check is currently disabled in code, so don't assert it was called
+        mock_check_domain.assert_called_once_with("test@example.com")
 
     @patch('app.dependencies.verify_jwt_token')
     @pytest.mark.asyncio
@@ -93,12 +93,11 @@ class TestGetCurrentUser:
         mock_extract_user.return_value = ("user-123", "test@blocked.com", "Test User", True)
         mock_check_domain.return_value = False
 
-        # Execute - should NOT raise exception because domain check is disabled
-        result = await get_current_user(mock_credentials)
+        # Execute - should raise ForbiddenError because domain is not allowed
+        with pytest.raises(ForbiddenError) as exc_info:
+            await get_current_user(mock_credentials)
         
-        # Verify user was created despite blocked domain (domain check disabled)
-        assert result.user_id == "user-123"
-        assert result.email == "test@blocked.com"
+        assert "Email domain not allowed" in str(exc_info.value)
 
     @patch('app.dependencies.verify_jwt_token')
     @patch('app.dependencies.extract_user_info')


### PR DESCRIPTION
## Issue
Re-enables the domain allowlist check that was temporarily disabled in get_current_user().

## Impact
- Restores the OTGS-only authentication boundary 
- Prevents any Google account from registering and creating teams/monitors
- Critical security fix for authentication bypass vulnerability

## Changes
- Uncommented domain allowlist check in dependencies.py (lines 72-74)
- Updated test_valid_token_success to assert domain check is called
- Updated test_domain_not_allowed to verify ForbiddenError is raised for disallowed domains

## Files Changed
- backend/app/dependencies.py: Re-enabled domain check
- backend/tests/test_dependencies.py: Updated tests to match new behavior

## Testing
Domain allowlist check now properly enforces allowed domains per environment configuration.

Fixes #35