### PR TITLE
Email alerts, Telegram delivery, dashboard fleet status, dialog UX cleanup

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -35,6 +35,15 @@ class Settings(BaseSettings):
     ping_retention_days: int = 90
     frontend_url: str = "https://pulsechecks.example.com"
 
+    # SMTP (email alert channels — cloud-agnostic; use SES SMTP on AWS,
+    # any provider (SendGrid, Mailgun, Workspace relay) on GCP)
+    smtp_host: str = ""
+    smtp_port: int = 587
+    smtp_username: str = ""
+    smtp_password: str = ""
+    smtp_from: str = ""  # e.g. "PulseChecks <alerts@example.com>"
+    smtp_use_tls: bool = True
+
     # PostHog
     posthog_api_key: str = ""
     posthog_host: str = "https://us.i.posthog.com"

--- a/backend/app/handlers.py
+++ b/backend/app/handlers.py
@@ -185,7 +185,12 @@ async def _send_primary_alerts(check, team, sns_client, metrics):
 async def _send_channel_alert(channel, check, team, sns_client, metrics, alert_type="late"):
     """Send alert via a specific AlertChannel. Returns success boolean."""
     from .models import AlertChannelType
-    
+
+    # The recovery path passes metrics=None; fall back to the real client so
+    # metric calls don't raise after the alert has already been delivered.
+    if metrics is None:
+        metrics = get_metrics_client()
+
     try:
         if channel.type == AlertChannelType.SNS:
             topic_arn = channel.configuration.get('topic_arn')
@@ -257,10 +262,43 @@ async def _send_channel_alert(channel, check, team, sns_client, metrics, alert_t
             return success
             
         elif channel.type == AlertChannelType.TELEGRAM:
-            # TODO: Implement Telegram integration
-            logger.info(f"Telegram alerts not yet implemented for channel {channel.name}")
-            return False
-            
+            bot_token = channel.configuration.get('bot_token')
+            chat_id = channel.configuration.get('chat_id')
+            if not bot_token or not chat_id:
+                return False
+
+            settings = get_settings()
+            check_url = f"{settings.frontend_url}/teams/{check.team_id}/checks/{check.check_id}"
+            if alert_type == "recovery":
+                text = f"✅ Check recovered: {check.name} ({team.name})\n{check_url}"
+            else:
+                text = f"⚠️ Check late: {check.name} ({team.name})\n{check_url}"
+
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    f"https://api.telegram.org/bot{bot_token}/sendMessage",
+                    json={"chat_id": chat_id, "text": text},
+                )
+                success = 200 <= response.status_code < 300
+
+            metrics.alert_sent(check.team_id, check.check_id, f'late_channel_{channel.type.value}', success)
+            return success
+
+        elif channel.type == AlertChannelType.EMAIL:
+            recipients = channel.configuration.get('recipients') or []
+            if not recipients:
+                return False
+
+            from .integrations.email import send_late_alert_email, send_recovery_alert_email
+            if alert_type == "recovery":
+                success = await send_recovery_alert_email(recipients, check, team.name)
+            else:
+                success = await send_late_alert_email(recipients, check, team.name)
+
+            metrics.alert_sent(check.team_id, check.check_id, f'late_channel_{channel.type.value}', success)
+            return success
+
+
     except Exception as e:
         logger.error(f"Failed to send alert via {channel.type.value} channel {channel.name}: {e}")
         metrics.alert_sent(check.team_id, check.check_id, f'late_channel_{channel.type.value}', False)

--- a/backend/app/integrations/email.py
+++ b/backend/app/integrations/email.py
@@ -1,0 +1,86 @@
+"""SMTP email integration for alert channels.
+
+Cloud-agnostic: works with SES SMTP on AWS and any SMTP provider
+(SendGrid, Mailgun, Google Workspace relay) on GCP. Uses the stdlib
+smtplib in a worker thread so no extra dependency is required.
+"""
+import asyncio
+import smtplib
+from email.message import EmailMessage
+from typing import List
+
+from ..config import get_settings
+import logging
+
+logger = logging.getLogger(__name__)
+
+SMTP_TIMEOUT = 15  # seconds
+
+
+class EmailNotConfiguredError(Exception):
+    """Raised when SMTP settings are missing on this deployment."""
+
+
+def _build_message(recipients: List[str], subject: str, body: str) -> EmailMessage:
+    settings = get_settings()
+    msg = EmailMessage()
+    msg["From"] = settings.smtp_from or settings.smtp_username
+    msg["To"] = ", ".join(recipients)
+    msg["Subject"] = subject
+    msg.set_content(body)
+    return msg
+
+
+def _send_sync(recipients: List[str], subject: str, body: str) -> None:
+    settings = get_settings()
+    if not settings.smtp_host:
+        raise EmailNotConfiguredError(
+            "SMTP is not configured on this deployment. "
+            "Set SMTP_HOST, SMTP_USERNAME, SMTP_PASSWORD, and SMTP_FROM."
+        )
+
+    msg = _build_message(recipients, subject, body)
+    with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=SMTP_TIMEOUT) as server:
+        if settings.smtp_use_tls:
+            server.starttls()
+        if settings.smtp_username:
+            server.login(settings.smtp_username, settings.smtp_password)
+        server.send_message(msg)
+
+
+async def send_email(recipients: List[str], subject: str, body: str) -> bool:
+    """Send an email to the given recipients. Returns success boolean."""
+    try:
+        await asyncio.to_thread(_send_sync, recipients, subject, body)
+        return True
+    except EmailNotConfiguredError:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to send email to {len(recipients)} recipient(s): {e}")
+        return False
+
+
+def _check_url(check) -> str:
+    settings = get_settings()
+    return f"{settings.frontend_url}/teams/{check.team_id}/checks/{check.check_id}"
+
+
+async def send_late_alert_email(recipients: List[str], check, team_name: str) -> bool:
+    subject = f"⚠️ [{team_name}] Check late: {check.name}"
+    body = (
+        f"The check \"{check.name}\" in team \"{team_name}\" has not reported in on time.\n\n"
+        f"Status: LATE\n"
+        f"Last ping: {check.last_ping_at or 'never'}\n\n"
+        f"View check: {_check_url(check)}\n"
+    )
+    return await send_email(recipients, subject, body)
+
+
+async def send_recovery_alert_email(recipients: List[str], check, team_name: str) -> bool:
+    subject = f"✅ [{team_name}] Check recovered: {check.name}"
+    body = (
+        f"The check \"{check.name}\" in team \"{team_name}\" is reporting in again.\n\n"
+        f"Status: UP\n\n"
+        f"View check: {_check_url(check)}\n"
+    )
+    return await send_email(recipients, subject, body)

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -57,3 +57,4 @@ class AlertChannelType(str, Enum):
     MATTERMOST = "mattermost"
     WEBHOOK = "webhook"
     TELEGRAM = "telegram"
+    EMAIL = "email"

--- a/backend/app/routers/channels.py
+++ b/backend/app/routers/channels.py
@@ -336,6 +336,20 @@ async def _send_test_notification(channel: "AlertChannel", team_id: str) -> None
             if resp.status_code >= 400:
                 raise ValueError(f"Telegram returned HTTP {resp.status_code}")
 
+    elif channel.type == AlertChannelType.EMAIL:
+        recipients = channel.configuration.get("recipients") or []
+        if not recipients:
+            raise ValueError("Email recipients not configured")
+        from ..integrations.email import send_email
+        success = await send_email(
+            recipients,
+            "🔔 PulseChecks Test Notification",
+            f"Test notification — channel \"{channel.display_name}\" is working.\n"
+            f"Team: {team_id}\nSent at: {get_iso_timestamp()}\n",
+        )
+        if not success:
+            raise ValueError("SMTP delivery failed — check server logs and SMTP settings")
+
     else:
         raise ValueError(f"Unsupported channel type: {channel.type.value}")
 
@@ -371,6 +385,26 @@ def _validate_channel_configuration(channel_type: AlertChannelType, config: Dict
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Telegram channels require 'bot_token' and 'chat_id' in configuration"
             )
+    elif channel_type == AlertChannelType.EMAIL:
+        import re
+        recipients = config.get("recipients")
+        if not recipients or not isinstance(recipients, list):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Email channels require 'recipients' (a list of email addresses) in configuration"
+            )
+        if len(recipients) > 20:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Email channels support at most 20 recipients"
+            )
+        email_re = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+        for recipient in recipients:
+            if not isinstance(recipient, str) or not email_re.match(recipient):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid email address: {recipient!r}"
+                )
 
 
 def _get_sns_client():

--- a/backend/tests/test_email_channel.py
+++ b/backend/tests/test_email_channel.py
@@ -1,0 +1,153 @@
+"""Tests for the email alert channel and Telegram delivery path."""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from fastapi import HTTPException
+
+from app.models import AlertChannel, AlertChannelType, Check, CheckStatus, Team
+from app.routers.channels import _validate_channel_configuration
+from app.handlers import _send_channel_alert
+from app.integrations.email import _send_sync, EmailNotConfiguredError
+
+
+def _make_check():
+    return Check(
+        check_id="check-1", team_id="team-1", name="Nightly Backup",
+        token="tok", period_seconds=3600, grace_seconds=300,
+        status=CheckStatus.LATE, created_at="2026-01-01T00:00:00Z",
+    )
+
+
+def _make_team():
+    return Team(
+        team_id="team-1", name="SRE", slug="sre",
+        created_at="2026-01-01T00:00:00Z", created_by="user-1",
+    )
+
+
+def _make_channel(channel_type, configuration):
+    return AlertChannel(
+        channel_id="chan-1", team_id="team-1", name="oncall",
+        display_name="On-call", type=channel_type,
+        configuration=configuration, shared=False,
+        created_at="2026-01-01T00:00:00Z", created_by="user-1",
+    )
+
+
+class TestEmailChannelValidation:
+    def test_valid_recipients_accepted(self):
+        _validate_channel_configuration(
+            AlertChannelType.EMAIL,
+            {"recipients": ["oncall@example.com", "sre@example.com"]},
+        )
+
+    def test_missing_recipients_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            _validate_channel_configuration(AlertChannelType.EMAIL, {})
+        assert exc.value.status_code == 400
+
+    def test_non_list_recipients_rejected(self):
+        with pytest.raises(HTTPException):
+            _validate_channel_configuration(
+                AlertChannelType.EMAIL, {"recipients": "oncall@example.com"}
+            )
+
+    def test_invalid_address_rejected(self):
+        with pytest.raises(HTTPException):
+            _validate_channel_configuration(
+                AlertChannelType.EMAIL, {"recipients": ["not-an-email"]}
+            )
+
+    def test_too_many_recipients_rejected(self):
+        recipients = [f"user{i}@example.com" for i in range(21)]
+        with pytest.raises(HTTPException):
+            _validate_channel_configuration(
+                AlertChannelType.EMAIL, {"recipients": recipients}
+            )
+
+
+class TestSmtpSend:
+    def test_unconfigured_smtp_raises(self):
+        settings = MagicMock()
+        settings.smtp_host = ""
+        with patch("app.integrations.email.get_settings", return_value=settings):
+            with pytest.raises(EmailNotConfiguredError):
+                _send_sync(["a@example.com"], "subject", "body")
+
+    def test_send_uses_tls_and_login(self):
+        settings = MagicMock()
+        settings.smtp_host = "smtp.example.com"
+        settings.smtp_port = 587
+        settings.smtp_username = "user"
+        settings.smtp_password = "pass"
+        settings.smtp_from = "PulseChecks <alerts@example.com>"
+        settings.smtp_use_tls = True
+
+        with patch("app.integrations.email.get_settings", return_value=settings), \
+             patch("app.integrations.email.smtplib.SMTP") as mock_smtp:
+            server = mock_smtp.return_value.__enter__.return_value
+            _send_sync(["a@example.com"], "subject", "body")
+
+        mock_smtp.assert_called_once_with("smtp.example.com", 587, timeout=15)
+        server.starttls.assert_called_once()
+        server.login.assert_called_once_with("user", "pass")
+        server.send_message.assert_called_once()
+        sent = server.send_message.call_args[0][0]
+        assert sent["To"] == "a@example.com"
+        assert sent["From"] == "PulseChecks <alerts@example.com>"
+
+
+class TestSendChannelAlert:
+    @pytest.mark.asyncio
+    async def test_email_channel_sends_late_alert(self):
+        channel = _make_channel(
+            AlertChannelType.EMAIL, {"recipients": ["oncall@example.com"]}
+        )
+        with patch(
+            "app.integrations.email.send_late_alert_email",
+            new=AsyncMock(return_value=True),
+        ) as mock_send:
+            ok = await _send_channel_alert(
+                channel, _make_check(), _make_team(), None, MagicMock()
+            )
+        assert ok is True
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args[0][0] == ["oncall@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_email_channel_without_recipients_fails(self):
+        channel = _make_channel(AlertChannelType.EMAIL, {})
+        ok = await _send_channel_alert(
+            channel, _make_check(), _make_team(), None, MagicMock()
+        )
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_telegram_channel_sends_message(self):
+        channel = _make_channel(
+            AlertChannelType.TELEGRAM,
+            {"bot_token": "123:abc", "chat_id": "-100"},
+        )
+        mock_response = MagicMock(status_code=200)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("app.handlers.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value.__aenter__.return_value = mock_client
+            ok = await _send_channel_alert(
+                channel, _make_check(), _make_team(), None, MagicMock()
+            )
+
+        assert ok is True
+        url = mock_client.post.await_args[0][0]
+        assert url == "https://api.telegram.org/bot123:abc/sendMessage"
+        payload = mock_client.post.await_args.kwargs["json"]
+        assert payload["chat_id"] == "-100"
+        assert "Nightly Backup" in payload["text"]
+
+    @pytest.mark.asyncio
+    async def test_telegram_channel_missing_config_fails(self):
+        channel = _make_channel(AlertChannelType.TELEGRAM, {"bot_token": "123:abc"})
+        ok = await _send_channel_alert(
+            channel, _make_check(), _make_team(), None, MagicMock()
+        )
+        assert ok is False

--- a/docs/alert-channels.md
+++ b/docs/alert-channels.md
@@ -61,8 +61,8 @@ Send notifications to Telegram chats via bot API.
   "displayName": "Operations Telegram",
   "type": "telegram",
   "configuration": {
-    "botToken": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz",
-    "chatId": "-1001234567890"
+    "bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz",
+    "chat_id": "-1001234567890"
   },
   "shared": false
 }
@@ -74,6 +74,32 @@ Send notifications to Telegram chats via bot API.
 3. Add bot to your group/channel
 4. Get chat ID (use @userinfobot or API)
 5. Create alert channel with bot token and chat ID
+
+### Email
+Send notifications by email over SMTP. Works on any cloud — configure the
+deployment with an SMTP provider (SES SMTP on AWS; SendGrid, Mailgun, or a
+Google Workspace relay on GCP).
+
+**Configuration:**
+```json
+{
+  "name": "oncall-email",
+  "displayName": "On-call Email",
+  "type": "email",
+  "configuration": {
+    "recipients": ["oncall@example.com", "sre-team@example.com"]
+  },
+  "shared": false
+}
+```
+
+Up to 20 recipients per channel.
+
+**Deployment prerequisites** (set once per deployment, via Terraform
+variables or environment variables): `SMTP_HOST`, `SMTP_PORT` (default 587),
+`SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`. If SMTP is not configured,
+email channels can be created but test notifications will fail with a clear
+error.
 
 ## Managing Alert Channels
 

--- a/frontend/src/__tests__/DashboardPage.test.jsx
+++ b/frontend/src/__tests__/DashboardPage.test.jsx
@@ -9,6 +9,7 @@ vi.mock('../lib/api', () => ({
   api: {
     listTeams: vi.fn(),
     createTeam: vi.fn(),
+    listChecks: vi.fn(),
   }
 }));
 
@@ -36,6 +37,7 @@ const mockUser = {
 describe('DashboardPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    api.listChecks.mockResolvedValue([]);
   });
 
   test('renders loading state initially', () => {
@@ -177,6 +179,41 @@ describe('DashboardPage', () => {
     fireEvent.click(screen.getByText('Cancel'));
     
     expect(screen.queryByText('Create Team')).not.toBeInTheDocument();
+  });
+
+  test('shows late-checks banner when a check is late', async () => {
+    api.listTeams.mockResolvedValue([
+      { teamId: 'team-1', name: 'SRE Team', role: 'admin', createdAt: '2023-01-01T00:00:00Z' }
+    ]);
+    api.listChecks.mockResolvedValue([
+      { checkId: 'check-1', teamId: 'team-1', name: 'Nightly Backup', status: 'late' },
+      { checkId: 'check-2', teamId: 'team-1', name: 'Hourly Sync', status: 'up' },
+    ]);
+
+    renderWithRouter(<DashboardPage user={mockUser} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('1 check is late')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Nightly Backup/)).toBeInTheDocument();
+    // KPI tiles present
+    expect(screen.getByText('Up')).toBeInTheDocument();
+    expect(screen.getByText('Late')).toBeInTheDocument();
+  });
+
+  test('shows all-operational banner when no checks are late', async () => {
+    api.listTeams.mockResolvedValue([
+      { teamId: 'team-1', name: 'SRE Team', role: 'admin', createdAt: '2023-01-01T00:00:00Z' }
+    ]);
+    api.listChecks.mockResolvedValue([
+      { checkId: 'check-1', teamId: 'team-1', name: 'Nightly Backup', status: 'up' },
+    ]);
+
+    renderWithRouter(<DashboardPage user={mockUser} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/All systems operational/)).toBeInTheDocument();
+    });
   });
 
   test('switches between grid and list view', async () => {

--- a/frontend/src/components/ConfirmDialog.jsx
+++ b/frontend/src/components/ConfirmDialog.jsx
@@ -1,0 +1,64 @@
+import { AlertTriangle, Trash2 } from 'lucide-react'
+
+/**
+ * Reusable confirmation modal, replacing native confirm().
+ *
+ * Usage:
+ *   const [confirmState, setConfirmState] = useState(null)
+ *   setConfirmState({
+ *     title: 'Delete channel',
+ *     message: 'Are you sure? This cannot be undone.',
+ *     confirmLabel: 'Delete',       // optional, default "Confirm"
+ *     destructive: true,            // optional, red styling + trash icon
+ *     onConfirm: () => { ... },
+ *   })
+ *   ...
+ *   <ConfirmDialog state={confirmState} onClose={() => setConfirmState(null)} />
+ */
+export default function ConfirmDialog({ state, onClose }) {
+  if (!state) return null
+
+  const { title, message, confirmLabel = 'Confirm', destructive = false, onConfirm } = state
+
+  function handleConfirm() {
+    onClose()
+    onConfirm()
+  }
+
+  const Icon = destructive ? Trash2 : AlertTriangle
+  const iconWrap = destructive ? 'bg-red-100' : 'bg-amber-100'
+  const iconColor = destructive ? 'text-red-600' : 'text-amber-600'
+  const confirmClasses = destructive
+    ? 'bg-red-600 hover:bg-red-700 focus:ring-red-300'
+    : 'bg-blue-600 hover:bg-blue-700 focus:ring-blue-300'
+
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50" role="dialog" aria-modal="true">
+      <div className="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+        <div className="mt-3 text-center">
+          <div className={`mx-auto flex items-center justify-center h-12 w-12 rounded-full ${iconWrap}`}>
+            <Icon className={`h-6 w-6 ${iconColor}`} aria-hidden="true" />
+          </div>
+          <h3 className="text-lg font-medium text-gray-900 mt-4">{title}</h3>
+          <div className="mt-2 px-7 py-3">
+            <p className="text-sm text-gray-500">{message}</p>
+          </div>
+          <div className="items-center px-4 py-3">
+            <button
+              onClick={handleConfirm}
+              className={`px-4 py-2 text-white text-base font-medium rounded-md w-full shadow-sm focus:outline-none focus:ring-2 ${confirmClasses}`}
+            >
+              {confirmLabel}
+            </button>
+            <button
+              onClick={onClose}
+              className="mt-3 px-4 py-2 bg-white text-gray-500 text-base font-medium rounded-md w-full shadow-sm border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-300"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/AlertChannelsPage.jsx
+++ b/frontend/src/pages/AlertChannelsPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, Trash2, Settings, Bell, MessageSquare, Send, Webhook, PlayCircle } from 'lucide-react'
+import { ArrowLeft, Plus, Trash2, Settings, Bell, MessageSquare, Send, Webhook, PlayCircle, Mail } from 'lucide-react'
 import Layout from '../components/Layout'
 import { api } from '../lib/api'
 import { useToast } from '../components/Toast'
@@ -10,7 +10,8 @@ const ALL_CHANNEL_TYPES = {
   sns: { name: 'SNS Topic', icon: Bell, color: 'blue' },
   mattermost: { name: 'Mattermost', icon: MessageSquare, color: 'purple' },
   webhook: { name: 'Webhook', icon: Webhook, color: 'indigo' },
-  telegram: { name: 'Telegram', icon: Send, color: 'sky' }
+  telegram: { name: 'Telegram', icon: Send, color: 'sky' },
+  email: { name: 'Email', icon: Mail, color: 'amber' }
 }
 
 // Filter channel types based on cloud provider
@@ -155,6 +156,24 @@ export default function AlertChannelsPage({ user, onLogout }) {
             className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
             required
           />
+        </div>
+      )
+    }
+
+    if (type === 'email') {
+      return (
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Recipients</label>
+          <input
+            type="text"
+            value={(newChannel.configuration.recipients || []).join(', ')}
+            onChange={(e) => handleConfigurationChange('recipients',
+              e.target.value.split(',').map(s => s.trim()).filter(Boolean))}
+            placeholder="oncall@example.com, sre-team@example.com"
+            className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+            required
+          />
+          <p className="mt-1 text-xs text-gray-500">Comma-separated, up to 20 addresses.</p>
         </div>
       )
     }

--- a/frontend/src/pages/AlertChannelsPage.jsx
+++ b/frontend/src/pages/AlertChannelsPage.jsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Plus, Trash2, Settings, Bell, MessageSquare, Send, Webhook, 
 import Layout from '../components/Layout'
 import { api } from '../lib/api'
 import { useToast } from '../components/Toast'
+import ConfirmDialog from '../components/ConfirmDialog'
 import { config } from '../config'
 
 const ALL_CHANNEL_TYPES = {
@@ -34,6 +35,7 @@ export default function AlertChannelsPage({ user, onLogout }) {
   const [loading, setLoading] = useState(true)
   const [testingChannel, setTestingChannel] = useState(null)
   const [showCreateChannel, setShowCreateChannel] = useState(false)
+  const [confirmState, setConfirmState] = useState(null)
   const [newChannel, setNewChannel] = useState({
     name: '',
     displayName: '',
@@ -76,15 +78,22 @@ export default function AlertChannelsPage({ user, onLogout }) {
     }
   }
 
-  async function handleDeleteChannel(channelId) {
-    if (!confirm('Are you sure you want to delete this alert channel?')) return
-
-    try {
-      await api.deleteAlertChannel(teamId, channelId)
-      loadChannels()
-    } catch (error) {
-      toast.error('Failed to delete channel: ' + error.message)
-    }
+  function handleDeleteChannel(channelId) {
+    setConfirmState({
+      title: 'Delete Alert Channel',
+      message: 'Are you sure you want to delete this alert channel? Checks using it will stop sending notifications through it.',
+      confirmLabel: 'Delete',
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.deleteAlertChannel(teamId, channelId)
+          toast.success('Alert channel deleted')
+          loadChannels()
+        } catch (error) {
+          toast.error('Failed to delete channel: ' + error.message)
+        }
+      },
+    })
   }
 
   async function handleTestChannel(channelId) {
@@ -396,6 +405,7 @@ export default function AlertChannelsPage({ user, onLogout }) {
           </div>
         )}
       </div>
+      <ConfirmDialog state={confirmState} onClose={() => setConfirmState(null)} />
     </Layout>
   )
 }

--- a/frontend/src/pages/CheckDetailPage.jsx
+++ b/frontend/src/pages/CheckDetailPage.jsx
@@ -6,6 +6,7 @@ import Layout from '../components/Layout'
 import { api } from '../lib/api'
 import { config } from '../config'
 import { useToast } from '../components/Toast'
+import ConfirmDialog from '../components/ConfirmDialog'
 import DurationInput from '../components/DurationInput'
 
 // Helper function to get the proper ping base URL (custom domain if available)
@@ -72,6 +73,7 @@ export default function CheckDetailPage({ user, onLogout }) {
   const [copied, setCopied] = useState(false)
   const [selectedPing, setSelectedPing] = useState(null)
   const [showTokenRotated, setShowTokenRotated] = useState(false)
+  const [confirmState, setConfirmState] = useState(null)
   const [availableTopics, setAvailableTopics] = useState([])
   const [availableChannels, setAvailableChannels] = useState([])
   const [teamSlug, setTeamSlug] = useState(null)
@@ -299,22 +301,7 @@ export default function CheckDetailPage({ user, onLogout }) {
       // Update with server response to ensure consistency
       setCheck(updatedCheck)
     } catch (error) {
-      alert('Failed to update alert channels: ' + error.message)
-      // Revert on error
-      loadCheckData()
-    }
-  }
-
-  async function updateCheckAlertTopics(selectedTopicArns) {
-    // Optimistic update
-    setCheck(prev => ({ ...prev, alertChannels: selectedTopicArns }))
-
-    try {
-      const updatedCheck = await api.updateCheck(teamId, checkId, { alertChannels: selectedTopicArns })
-      // Update with server response to ensure consistency
-      setCheck(updatedCheck)
-    } catch (error) {
-      alert('Failed to update alert topics: ' + error.message)
+      toast.error('Failed to update alert channels: ' + error.message)
       // Revert on error
       loadCheckData()
     }
@@ -325,7 +312,7 @@ export default function CheckDetailPage({ user, onLogout }) {
       await api.pauseCheck(teamId, checkId)
       loadCheckData()
     } catch (error) {
-      alert('Failed to pause check: ' + error.message)
+      toast.error('Failed to pause check: ' + error.message)
     }
   }
 
@@ -334,39 +321,46 @@ export default function CheckDetailPage({ user, onLogout }) {
       await api.resumeCheck(teamId, checkId)
       loadCheckData()
     } catch (error) {
-      alert('Failed to resume check: ' + error.message)
+      toast.error('Failed to resume check: ' + error.message)
     }
   }
 
-  async function handleRotateToken() {
-    if (!confirm('Are you sure you want to rotate the token? The old ping URL will stop working immediately.')) {
-      return
-    }
-
-    try {
-      const updatedCheck = await api.rotateCheckToken(teamId, checkId)
-      // Update check with new token and ping URL
-      updatedCheck.pingUrl = `${getPingBaseUrl()}/ping/${updatedCheck.token}`
-      setCheck(updatedCheck)
-      setShowTokenRotated(true)
-      toast.success('Token rotated successfully')
-    } catch (error) {
-      toast.error('Failed to rotate token: ' + error.message)
-    }
+  function handleRotateToken() {
+    setConfirmState({
+      title: 'Rotate Token',
+      message: 'Are you sure you want to rotate the token? The old ping URL will stop working immediately.',
+      confirmLabel: 'Rotate Token',
+      onConfirm: async () => {
+        try {
+          const updatedCheck = await api.rotateCheckToken(teamId, checkId)
+          // Update check with new token and ping URL
+          updatedCheck.pingUrl = `${getPingBaseUrl()}/ping/${updatedCheck.token}`
+          setCheck(updatedCheck)
+          setShowTokenRotated(true)
+          toast.success('Token rotated successfully')
+        } catch (error) {
+          toast.error('Failed to rotate token: ' + error.message)
+        }
+      },
+    })
   }
 
-  async function handleDeleteCheck() {
-    if (!confirm(`Are you sure you want to delete "${check.name}"? This action cannot be undone and will delete all ping history.`)) {
-      return
-    }
-
-    try {
-      await api.deleteCheck(teamId, checkId)
-      alert('Check deleted successfully')
-      navigate(`/teams/${teamId}/checks`)
-    } catch (error) {
-      alert('Failed to delete check: ' + error.message)
-    }
+  function handleDeleteCheck() {
+    setConfirmState({
+      title: 'Delete Check',
+      message: `Are you sure you want to delete "${check.name}"? This action cannot be undone and will delete all ping history.`,
+      confirmLabel: 'Delete',
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.deleteCheck(teamId, checkId)
+          toast.success('Check deleted successfully')
+          navigate(`/teams/${teamId}/checks`)
+        } catch (error) {
+          toast.error('Failed to delete check: ' + error.message)
+        }
+      },
+    })
   }
 
   function openEditHttpCheck() {
@@ -1113,6 +1107,15 @@ export default function CheckDetailPage({ user, onLogout }) {
               <h3 className="text-lg leading-6 font-medium text-gray-900 flex items-center">
                 <Bell className="h-5 w-5 mr-2" />
                 Alert Configuration
+                {(check.alertChannels || []).length > 0 ? (
+                  <span className="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                    {check.alertChannels.length} {check.alertChannels.length === 1 ? 'channel' : 'channels'} active
+                  </span>
+                ) : (
+                  <span className="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                    ⚠ No channels — alerts disabled
+                  </span>
+                )}
               </h3>
               <p className="mt-1 max-w-2xl text-sm text-gray-500">
                 Configure notifications, escalation, and suppression for this check
@@ -1455,6 +1458,7 @@ curl ${check.pingUrl}/start`}
           </div>
         </div>
       )}
+      <ConfirmDialog state={confirmState} onClose={() => setConfirmState(null)} />
     </Layout>
   )
 }

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Plus, Users, Grid3X3, List } from 'lucide-react'
+import { Plus, Users, Grid3X3, List, CheckCircle, AlertCircle, Clock, PauseCircle } from 'lucide-react'
 import Layout from '../components/Layout'
 import { api } from '../lib/api'
 import { useToast } from '../components/Toast'
@@ -9,28 +9,81 @@ export default function DashboardPage({ user, onLogout }) {
   const navigate = useNavigate()
   const toast = useToast()
   const [teams, setTeams] = useState([])
+  const [checksByTeam, setChecksByTeam] = useState(null) // null = not yet loaded
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [showCreateTeam, setShowCreateTeam] = useState(false)
   const [newTeamName, setNewTeamName] = useState('')
   const [creating, setCreating] = useState(false)
-  const [viewMode, setViewMode] = useState('grid')
-  
+  const [viewMode, setViewMode] = useState(() => localStorage.getItem('dashboardViewMode') || 'grid')
+
   useEffect(() => {
     loadTeams()
+    const interval = setInterval(loadTeams, 60000) // Refresh fleet status every 60s
+    return () => clearInterval(interval)
   }, [])
-  
+
+  useEffect(() => {
+    localStorage.setItem('dashboardViewMode', viewMode)
+  }, [viewMode])
+
   async function loadTeams() {
     try {
       const data = await api.listTeams()
       // Backend returns array directly, not wrapped in {teams: [...]}
-      setTeams(Array.isArray(data) ? data : data.teams || [])
+      const loadedTeams = Array.isArray(data) ? data : data.teams || []
+      setTeams(loadedTeams)
       setError(null)
+      loadFleetStatus(loadedTeams)
     } catch {
       setError('Failed to load teams. Please try again.')
     } finally {
       setLoading(false)
     }
+  }
+
+  async function loadFleetStatus(loadedTeams) {
+    const results = await Promise.all(
+      loadedTeams.map(async (team) => {
+        try {
+          const data = await api.listChecks(team.teamId)
+          return [team.teamId, Array.isArray(data) ? data : data.checks || []]
+        } catch {
+          return [team.teamId, null] // null = failed to load, distinct from empty
+        }
+      })
+    )
+    setChecksByTeam(Object.fromEntries(results))
+  }
+
+  const fleet = (() => {
+    if (!checksByTeam) return null
+    const summary = { up: 0, late: 0, pending: 0, paused: 0, total: 0, lateChecks: [] }
+    for (const team of teams) {
+      const checks = checksByTeam[team.teamId]
+      if (!checks) continue
+      for (const check of checks) {
+        summary.total++
+        if (check.status === 'late') {
+          summary.late++
+          summary.lateChecks.push({ ...check, teamName: team.name })
+        } else if (check.status === 'paused') {
+          summary.paused++
+        } else if (check.status === 'pending') {
+          summary.pending++
+        } else {
+          summary.up++
+        }
+      }
+    }
+    return summary
+  })()
+
+  function teamStatusSummary(teamId) {
+    const checks = checksByTeam?.[teamId]
+    if (!checks) return null
+    const late = checks.filter(c => c.status === 'late').length
+    return { total: checks.length, late }
   }
   
   async function handleCreateTeam(e) {
@@ -54,6 +107,61 @@ export default function DashboardPage({ user, onLogout }) {
   return (
     <Layout user={user} onLogout={onLogout}>
       <div className="space-y-6">
+        {/* Fleet status — answers "is anything down right now?" */}
+        {fleet && fleet.total > 0 && (
+          <div className="space-y-4">
+            {fleet.lateChecks.length > 0 ? (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                <div className="flex items-center mb-2">
+                  <AlertCircle className="h-5 w-5 text-red-500 mr-2" aria-hidden="true" />
+                  <h2 className="text-sm font-semibold text-red-800">
+                    {fleet.lateChecks.length} {fleet.lateChecks.length === 1 ? 'check is' : 'checks are'} late
+                  </h2>
+                </div>
+                <ul className="space-y-1">
+                  {fleet.lateChecks.slice(0, 10).map((check) => (
+                    <li key={check.checkId}>
+                      <button
+                        onClick={() => navigate(`/teams/${check.teamId}/checks/${check.checkId}`)}
+                        className="text-sm text-red-700 hover:text-red-900 hover:underline"
+                      >
+                        {check.name} <span className="text-red-500">— {check.teamName}</span>
+                      </button>
+                    </li>
+                  ))}
+                  {fleet.lateChecks.length > 10 && (
+                    <li className="text-sm text-red-500">…and {fleet.lateChecks.length - 10} more</li>
+                  )}
+                </ul>
+              </div>
+            ) : (
+              <div className="bg-green-50 border border-green-200 rounded-lg px-4 py-3 flex items-center">
+                <CheckCircle className="h-5 w-5 text-green-500 mr-2" aria-hidden="true" />
+                <p className="text-sm font-medium text-green-800">
+                  All systems operational — {fleet.up} {fleet.up === 1 ? 'check' : 'checks'} up
+                </p>
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              {[
+                { label: 'Up', count: fleet.up, Icon: CheckCircle, iconColor: 'text-green-500' },
+                { label: 'Late', count: fleet.late, Icon: AlertCircle, iconColor: 'text-red-500' },
+                { label: 'Pending', count: fleet.pending, Icon: Clock, iconColor: 'text-amber-500' },
+                { label: 'Paused', count: fleet.paused, Icon: PauseCircle, iconColor: 'text-gray-400' },
+              ].map(({ label, count, Icon, iconColor }) => (
+                <div key={label} className="bg-white shadow rounded-lg px-4 py-3 flex items-center">
+                  <Icon className={`h-6 w-6 ${iconColor} mr-3 flex-shrink-0`} aria-hidden="true" />
+                  <div>
+                    <p className="text-2xl font-semibold text-gray-900">{count}</p>
+                    <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
         <div className="flex justify-between items-center">
           <h1 className="text-3xl font-bold text-gray-900">Your Teams</h1>
           <div className="flex items-center space-x-3">
@@ -190,6 +298,21 @@ export default function DashboardPage({ user, onLogout }) {
                         </dl>
                       </div>
                     </div>
+                    {(() => {
+                      const status = teamStatusSummary(team.teamId)
+                      if (!status) return null
+                      return (
+                        <p className="mt-2 text-sm">
+                          <span className="text-gray-500">{status.total} {status.total === 1 ? 'check' : 'checks'}</span>
+                          {status.late > 0 && (
+                            <span className="ml-2 inline-flex items-center font-medium text-red-700">
+                              <AlertCircle className="h-4 w-4 mr-1" aria-hidden="true" />
+                              {status.late} late
+                            </span>
+                          )}
+                        </p>
+                      )
+                    })()}
                     <div className="mt-4 flex items-center justify-between">
                       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                         {team.role}
@@ -224,6 +347,21 @@ export default function DashboardPage({ user, onLogout }) {
                         <div className="flex items-center space-x-3">
                           <Users className="h-5 w-5 text-gray-400" />
                           <p className="text-sm font-medium text-blue-600 truncate">{team.name}</p>
+                          {(() => {
+                            const status = teamStatusSummary(team.teamId)
+                            if (!status) return null
+                            return (
+                              <span className="text-sm text-gray-500">
+                                {status.total} {status.total === 1 ? 'check' : 'checks'}
+                                {status.late > 0 && (
+                                  <span className="ml-2 inline-flex items-center font-medium text-red-700">
+                                    <AlertCircle className="h-4 w-4 mr-1" aria-hidden="true" />
+                                    {status.late} late
+                                  </span>
+                                )}
+                              </span>
+                            )
+                          })()}
                         </div>
                         <div className="flex items-center space-x-3">
                           <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">

--- a/frontend/src/pages/SharedAlertsPage.jsx
+++ b/frontend/src/pages/SharedAlertsPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { ArrowLeft, Bell, Users, MessageSquare, Send, Plus, Settings, Trash2, Webhook } from 'lucide-react'
+import { ArrowLeft, Bell, Users, MessageSquare, Send, Plus, Settings, Trash2, Webhook, Mail } from 'lucide-react'
 import Layout from '../components/Layout'
 import { api } from '../lib/api'
 import { useToast } from '../components/Toast'
@@ -11,6 +11,7 @@ const ALL_CHANNEL_TYPES = [
   { value: 'mattermost', label: 'Mattermost' },
   { value: 'webhook', label: 'Webhook' },
   { value: 'telegram', label: 'Telegram' },
+  { value: 'email', label: 'Email' },
 ]
 
 const CHANNEL_TYPES = ALL_CHANNEL_TYPES.filter(
@@ -279,6 +280,24 @@ export default function SharedAlertsPage({ user, onLogout }) {
                   </div>
                 )}
 
+                {newChannel.type === 'email' && (
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">Recipients</label>
+                    <input
+                      type="text"
+                      value={(newChannel.configuration.recipients || []).join(', ')}
+                      onChange={(e) => setNewChannel(prev => ({
+                        ...prev,
+                        configuration: { recipients: e.target.value.split(',').map(s => s.trim()).filter(Boolean) }
+                      }))}
+                      placeholder="oncall@example.com, sre-team@example.com"
+                      className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                      required
+                    />
+                    <p className="mt-1 text-xs text-gray-500">Comma-separated, up to 20 addresses.</p>
+                  </div>
+                )}
+
                 {newChannel.type === 'sns' && (
                   <div>
                     <label className="block text-sm font-medium text-gray-700">SNS Topic ARN</label>
@@ -336,6 +355,7 @@ export default function SharedAlertsPage({ user, onLogout }) {
                         {channel.type === 'mattermost' && <MessageSquare className="h-8 w-8 text-purple-500" />}
                         {channel.type === 'webhook' && <Webhook className="h-8 w-8 text-indigo-500" />}
                         {channel.type === 'telegram' && <Send className="h-8 w-8 text-sky-500" />}
+                        {channel.type === 'email' && <Mail className="h-8 w-8 text-amber-500" />}
                       </div>
                       <div className="ml-4">
                         <div className="text-sm font-medium text-gray-900">
@@ -430,6 +450,23 @@ export default function SharedAlertsPage({ user, onLogout }) {
                           required
                         />
                       </div>
+                    </div>
+                  )}
+
+                  {editingChannel.type === 'email' && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700">Recipients</label>
+                      <input
+                        type="text"
+                        value={(editingChannel.configuration?.recipients || []).join(', ')}
+                        onChange={(e) => setEditingChannel({
+                          ...editingChannel,
+                          configuration: { ...editingChannel.configuration, recipients: e.target.value.split(',').map(s => s.trim()).filter(Boolean) }
+                        })}
+                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                        required
+                      />
+                      <p className="mt-1 text-xs text-gray-500">Comma-separated, up to 20 addresses.</p>
                     </div>
                   )}
 

--- a/frontend/src/pages/SharedAlertsPage.jsx
+++ b/frontend/src/pages/SharedAlertsPage.jsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Bell, Users, MessageSquare, Send, Plus, Settings, Trash2, We
 import Layout from '../components/Layout'
 import { api } from '../lib/api'
 import { useToast } from '../components/Toast'
+import ConfirmDialog from '../components/ConfirmDialog'
 import { config } from '../config'
 
 const ALL_CHANNEL_TYPES = [
@@ -26,6 +27,7 @@ export default function SharedAlertsPage({ user, onLogout }) {
   const [loading, setLoading] = useState(true)
   const [showAddChannel, setShowAddChannel] = useState(false)
   const [editingChannel, setEditingChannel] = useState(null)
+  const [confirmState, setConfirmState] = useState(null)
   const [newChannel, setNewChannel] = useState({
     name: '',
     displayName: '',
@@ -97,16 +99,22 @@ export default function SharedAlertsPage({ user, onLogout }) {
     }
   }
 
-  async function handleDeleteChannel(channel) {
-    if (!confirm(`Are you sure you want to delete "${channel.displayName}"?`)) return
-
-    try {
-      await api.deleteAlertChannel(channel.teamId, channel.channelId)
-      toast.success('Channel deleted successfully')
-      loadSharedChannels()
-    } catch (error) {
-      toast.error('Failed to delete channel: ' + error.message)
-    }
+  function handleDeleteChannel(channel) {
+    setConfirmState({
+      title: 'Delete Shared Channel',
+      message: `Are you sure you want to delete "${channel.displayName}"? Checks in all teams using it will stop sending notifications through it.`,
+      confirmLabel: 'Delete',
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.deleteAlertChannel(channel.teamId, channel.channelId)
+          toast.success('Channel deleted successfully')
+          loadSharedChannels()
+        } catch (error) {
+          toast.error('Failed to delete channel: ' + error.message)
+        }
+      },
+    })
   }
 
   async function handleUpdateChannel(e) {
@@ -491,6 +499,7 @@ export default function SharedAlertsPage({ user, onLogout }) {
           </div>
         )}
       </div>
+      <ConfirmDialog state={confirmState} onClose={() => setConfirmState(null)} />
     </Layout>
   )
 }

--- a/frontend/src/pages/TeamSettingsPage.jsx
+++ b/frontend/src/pages/TeamSettingsPage.jsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Users, Plus, Trash2, Shield, Bell, Webhook, Settings, X, Mes
 import Layout from '../components/Layout'
 import { api } from '../lib/api'
 import { useToast } from '../components/Toast'
+import ConfirmDialog from '../components/ConfirmDialog'
 
 function toDateTimeLocalValue(date) {
   const offsetMilliseconds = date.getTimezoneOffset() * 60000
@@ -34,9 +35,6 @@ export default function TeamSettingsPage({ user, onLogout }) {
   const [testingChannel, setTestingChannel] = useState(null)
   const [showAddMember, setShowAddMember] = useState(false)
   const [showAddAlert, setShowAddAlert] = useState(false)
-  const [showTopicDetails, setShowTopicDetails] = useState(false)
-  const [selectedTopic, setSelectedTopic] = useState(null)
-  const [topicDetails, setTopicDetails] = useState(null)
   const [newMemberEmail, setNewMemberEmail] = useState('')
   const [newMemberRole, setNewMemberRole] = useState('member')
   const [newAlertName, setNewAlertName] = useState('')
@@ -46,13 +44,12 @@ export default function TeamSettingsPage({ user, onLogout }) {
   const [newChannelConfig, setNewChannelConfig] = useState({})
   const [channels, setChannels] = useState([])
   const [editingChannel, setEditingChannel] = useState(null)
-  const [newSubscriptionProtocol, setNewSubscriptionProtocol] = useState('email')
-  const [newSubscriptionEndpoint, setNewSubscriptionEndpoint] = useState('')
   const [mattermostWebhook, setMattermostWebhook] = useState('')
   const [mattermostLoading, setMattermostLoading] = useState(false)
   const [mattermostWebhooks, setMattermostWebhooks] = useState([])
   const [newWebhookUrl, setNewWebhookUrl] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [confirmState, setConfirmState] = useState(null)
   const [deleteConfirmText, setDeleteConfirmText] = useState('')
   const [deleteLoading, setDeleteLoading] = useState(false)
   const [apiTokens, setApiTokens] = useState([])
@@ -113,36 +110,52 @@ export default function TeamSettingsPage({ user, onLogout }) {
     if (!newMemberEmail.trim()) return
 
     try {
-      await api.addTeamMember(teamId, newMemberEmail.trim(), newMemberRole)
+      const invitedEmail = newMemberEmail.trim()
+      await api.addTeamMember(teamId, invitedEmail, newMemberRole)
       setNewMemberEmail('')
       setNewMemberRole('member')
       setShowAddMember(false)
+      toast.success(`Invitation sent to ${invitedEmail}`)
       loadMembers()
     } catch (error) {
-      alert('Failed to add member: ' + error.message)
+      toast.error('Failed to add member: ' + error.message)
     }
   }
 
-  async function handleRemoveMember(userId) {
-    if (!confirm('Are you sure you want to remove this member?')) return
-
-    try {
-      await api.removeTeamMember(teamId, userId)
-      loadMembers()
-    } catch (error) {
-      alert('Failed to remove member: ' + error.message)
-    }
+  function handleRemoveMember(userId) {
+    setConfirmState({
+      title: 'Remove Member',
+      message: 'Are you sure you want to remove this member from the team?',
+      confirmLabel: 'Remove',
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.removeTeamMember(teamId, userId)
+          toast.success('Member removed')
+          loadMembers()
+        } catch (error) {
+          toast.error('Failed to remove member: ' + error.message)
+        }
+      },
+    })
   }
 
-  async function handleDeleteInvitation(email) {
-    if (!confirm('Are you sure you want to delete this invitation?')) return
-
-    try {
-      await api.deleteTeamInvitation(teamId, email)
-      loadMembers()
-    } catch (error) {
-      alert('Failed to delete invitation: ' + error.message)
-    }
+  function handleDeleteInvitation(email) {
+    setConfirmState({
+      title: 'Delete Invitation',
+      message: `Delete the pending invitation for ${email}?`,
+      confirmLabel: 'Delete',
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.deleteTeamInvitation(teamId, email)
+          toast.success('Invitation deleted')
+          loadMembers()
+        } catch (error) {
+          toast.error('Failed to delete invitation: ' + error.message)
+        }
+      },
+    })
   }
 
   async function loadMattermostWebhook() {
@@ -157,9 +170,9 @@ export default function TeamSettingsPage({ user, onLogout }) {
     setMattermostLoading(true)
     try {
       await api.updateTeamMattermostWebhook(teamId, mattermostWebhook)
-      alert('Mattermost webhook updated successfully!')
+      toast.success('Mattermost webhook updated successfully')
     } catch (error) {
-      alert('Failed to update Mattermost webhook: ' + error.message)
+      toast.error('Failed to update Mattermost webhook: ' + error.message)
     } finally {
       setMattermostLoading(false)
     }
@@ -179,21 +192,29 @@ export default function TeamSettingsPage({ user, onLogout }) {
     try {
       await api.addTeamMattermostWebhook(teamId, newWebhookUrl.trim())
       setNewWebhookUrl('')
+      toast.success('Webhook added')
       loadMattermostWebhooks()
     } catch (error) {
-      alert('Failed to add webhook: ' + error.message)
+      toast.error('Failed to add webhook: ' + error.message)
     }
   }
 
-  async function handleRemoveWebhook(webhookUrl) {
-    if (!confirm('Are you sure you want to remove this webhook?')) return
-
-    try {
-      await api.removeTeamMattermostWebhook(teamId, webhookUrl)
-      loadMattermostWebhooks()
-    } catch (error) {
-      alert('Failed to remove webhook: ' + error.message)
-    }
+  function handleRemoveWebhook(webhookUrl) {
+    setConfirmState({
+      title: 'Remove Webhook',
+      message: 'Are you sure you want to remove this webhook?',
+      confirmLabel: 'Remove',
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.removeTeamMattermostWebhook(teamId, webhookUrl)
+          toast.success('Webhook removed')
+          loadMattermostWebhooks()
+        } catch (error) {
+          toast.error('Failed to remove webhook: ' + error.message)
+        }
+      },
+    })
   }
 
   async function handleRoleChange(userId, newRole) {
@@ -201,7 +222,7 @@ export default function TeamSettingsPage({ user, onLogout }) {
       await api.updateTeamMemberRole(teamId, userId, newRole)
       loadMembers()
     } catch (error) {
-      alert('Failed to update role: ' + error.message)
+      toast.error('Failed to update role: ' + error.message)
     }
   }
 
@@ -225,9 +246,10 @@ export default function TeamSettingsPage({ user, onLogout }) {
       setNewChannelConfig({})
       setNewAlertShared(false)
       setShowAddAlert(false)
+      toast.success('Alert channel created')
       loadChannels()
     } catch (error) {
-      alert('Failed to create channel: ' + error.message)
+      toast.error('Failed to create channel: ' + error.message)
     }
   }
 
@@ -306,15 +328,22 @@ export default function TeamSettingsPage({ user, onLogout }) {
     }
   }
 
-  async function handleDeleteReport(reportId) {
-    if (!confirm('Delete this generated report?')) return
-    try {
-      await api.deleteReport(teamId, reportId)
-      toast.success('Report deleted')
-      loadReports()
-    } catch (error) {
-      toast.error('Failed to delete report: ' + error.message)
-    }
+  function handleDeleteReport(reportId) {
+    setConfirmState({
+      title: 'Delete Report',
+      message: 'Delete this generated report? The download link will stop working.',
+      confirmLabel: 'Delete',
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.deleteReport(teamId, reportId)
+          toast.success('Report deleted')
+          loadReports()
+        } catch (error) {
+          toast.error('Failed to delete report: ' + error.message)
+        }
+      },
+    })
   }
 
   async function handleCreateToken(e) {
@@ -327,29 +356,44 @@ export default function TeamSettingsPage({ user, onLogout }) {
       setShowCreateToken(false)
       loadApiTokens()
     } catch (error) {
-      alert('Failed to create token: ' + error.message)
+      toast.error('Failed to create token: ' + error.message)
     }
   }
 
-  async function handleRevokeToken(tokenId) {
-    if (!confirm('Revoke this token? Any scripts using it will stop working.')) return
-    try {
-      await api.revokeApiToken(teamId, tokenId)
-      loadApiTokens()
-    } catch (error) {
-      alert('Failed to revoke token: ' + error.message)
-    }
+  function handleRevokeToken(tokenId) {
+    setConfirmState({
+      title: 'Revoke API Token',
+      message: 'Revoke this token? Any scripts using it will stop working immediately.',
+      confirmLabel: 'Revoke',
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.revokeApiToken(teamId, tokenId)
+          toast.success('Token revoked')
+          loadApiTokens()
+        } catch (error) {
+          toast.error('Failed to revoke token: ' + error.message)
+        }
+      },
+    })
   }
 
-  async function handleDeleteChannel(channelId) {
-    if (!confirm('Are you sure you want to delete this alert channel?')) return
-
-    try {
-      await api.deleteAlertChannel(teamId, channelId)
-      loadChannels()
-    } catch (error) {
-      alert('Failed to delete channel: ' + error.message)
-    }
+  function handleDeleteChannel(channelId) {
+    setConfirmState({
+      title: 'Delete Alert Channel',
+      message: 'Are you sure you want to delete this alert channel? Checks using it will stop sending notifications through it.',
+      confirmLabel: 'Delete',
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.deleteAlertChannel(teamId, channelId)
+          toast.success('Alert channel deleted')
+          loadChannels()
+        } catch (error) {
+          toast.error('Failed to delete channel: ' + error.message)
+        }
+      },
+    })
   }
 
   async function handleTestChannel(channelId) {
@@ -407,6 +451,23 @@ export default function TeamSettingsPage({ user, onLogout }) {
       )
     }
 
+    if (newChannelType === 'email') {
+      return (
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Recipients</label>
+          <input
+            type="text"
+            value={(newChannelConfig.recipients || []).join(', ')}
+            onChange={(e) => setNewChannelConfig({ recipients: e.target.value.split(',').map(s => s.trim()).filter(Boolean) })}
+            placeholder="oncall@example.com, sre-team@example.com"
+            className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+            required
+          />
+          <p className="mt-1 text-xs text-gray-500">Comma-separated, up to 20 addresses.</p>
+        </div>
+      )
+    }
+
     if (newChannelType === 'telegram') {
       return (
         <div className="space-y-4">
@@ -451,9 +512,10 @@ export default function TeamSettingsPage({ user, onLogout }) {
 
       await api.updateAlertChannel(teamId, editingChannel.channelId, updateData)
       setEditingChannel(null)
+      toast.success('Channel updated')
       loadChannels()
     } catch (error) {
-      alert('Failed to update channel: ' + error.message)
+      toast.error('Failed to update channel: ' + error.message)
     }
   }
 
@@ -496,6 +558,25 @@ export default function TeamSettingsPage({ user, onLogout }) {
       )
     }
 
+    if (editingChannel.type === 'email') {
+      return (
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Recipients</label>
+          <input
+            type="text"
+            value={(editingChannel.configuration?.recipients || []).join(', ')}
+            onChange={(e) => setEditingChannel({
+              ...editingChannel,
+              configuration: { ...editingChannel.configuration, recipients: e.target.value.split(',').map(s => s.trim()).filter(Boolean) }
+            })}
+            className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+            required
+          />
+          <p className="mt-1 text-xs text-gray-500">Comma-separated, up to 20 addresses.</p>
+        </div>
+      )
+    }
+
     if (editingChannel.type === 'telegram') {
       return (
         <div className="space-y-4">
@@ -532,71 +613,19 @@ export default function TeamSettingsPage({ user, onLogout }) {
     return null
   }
 
-  async function handleDeleteAlert(topicArn) {
-    // Legacy alert topics are no longer supported
-    alert('Alert topics have been replaced with alert channels. Please use the Channels page to manage notifications.')
-  }
-
-  async function handleShowTopicDetails(topic) {
-    setSelectedTopic(topic)
-    setShowTopicDetails(true)
-    try {
-      const topicArn = topic.topicArn || topic.topic_arn
-      if (!topicArn) {
-        alert('Topic ARN not found.')
-        return
-      }
-      const details = await api.getAlertTopicDetails(teamId, topicArn)
-      setTopicDetails(details)
-    } catch {
-      setTopicDetails(null)
-    }
-  }
-
-  async function handleSubscribe(e) {
-    e.preventDefault()
-    if (!selectedTopic || !newSubscriptionEndpoint.trim()) return
-
-    try {
-      const topicArn = selectedTopic.topicArn || selectedTopic.topic_arn
-      // Legacy subscription functionality no longer supported
-      alert('Alert topic subscriptions have been replaced with alert channels. Please use the Channels page to manage notifications.')
-      setNewSubscriptionEndpoint('')
-      alert('Subscription created! Check your email/endpoint for confirmation.')
-      // Reload topic details
-      handleShowTopicDetails(selectedTopic)
-    } catch (error) {
-      alert('Failed to subscribe: ' + error.message)
-    }
-  }
-
-  async function handleUnsubscribe(subscriptionArn) {
-    if (!confirm('Are you sure you want to unsubscribe?')) return
-
-    try {
-      const topicArn = selectedTopic.topicArn || selectedTopic.topic_arn
-      await api.unsubscribeFromAlertTopic(teamId, topicArn, subscriptionArn)
-      alert('Unsubscribed successfully!')
-      // Reload topic details
-      handleShowTopicDetails(selectedTopic)
-    } catch (error) {
-      alert('Failed to unsubscribe: ' + error.message)
-    }
-  }
-
   async function handleDeleteTeam() {
     if (deleteConfirmText !== team?.name) {
-      alert('Please type the team name exactly to confirm deletion')
+      toast.error('Please type the team name exactly to confirm deletion')
       return
     }
 
     setDeleteLoading(true)
     try {
       await api.deleteTeam(teamId, team.name)
-      alert(`Team "${team.name}" has been permanently deleted`)
+      toast.success(`Team "${team.name}" has been permanently deleted`)
       navigate('/')
     } catch (error) {
-      alert('Failed to delete team: ' + error.message)
+      toast.error('Failed to delete team: ' + error.message)
     } finally {
       setDeleteLoading(false)
     }
@@ -901,6 +930,7 @@ export default function TeamSettingsPage({ user, onLogout }) {
                       <option value="mattermost">Mattermost</option>
                       <option value="webhook">Webhook</option>
                       <option value="telegram">Telegram</option>
+                      <option value="email">Email</option>
                     </select>
                   </div>
 
@@ -1390,6 +1420,7 @@ export default function TeamSettingsPage({ user, onLogout }) {
           </div>
         )}
       </div>
+      <ConfirmDialog state={confirmState} onClose={() => setConfirmState(null)} />
     </Layout>
   )
 }

--- a/infra/aws/lambdas.tf
+++ b/infra/aws/lambdas.tf
@@ -139,6 +139,11 @@ resource "aws_lambda_function" "api" {
       ALLOWED_EMAIL_DOMAINS = var.allowed_email_domains
       COGNITO_CLIENT_ID     = aws_cognito_user_pool_client.main.id
       COGNITO_USER_POOL_ID  = aws_cognito_user_pool.main.id
+      SMTP_HOST             = var.smtp_host
+      SMTP_PORT             = var.smtp_port
+      SMTP_USERNAME         = var.smtp_username
+      SMTP_PASSWORD         = var.smtp_password
+      SMTP_FROM             = var.smtp_from
     }
   }
 
@@ -165,6 +170,11 @@ resource "aws_lambda_function" "late_detector" {
   environment {
     variables = {
       DYNAMODB_TABLE = aws_dynamodb_table.pulsechecks.name
+      SMTP_HOST      = var.smtp_host
+      SMTP_PORT      = var.smtp_port
+      SMTP_USERNAME  = var.smtp_username
+      SMTP_PASSWORD  = var.smtp_password
+      SMTP_FROM      = var.smtp_from
     }
   }
 

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -66,3 +66,36 @@ variable "domain_name" {
   default     = "pulsechecks.example.com"
 }
 
+
+# SMTP settings for email alert channels (optional). Leave empty to
+# disable email channels on this deployment.
+variable "smtp_host" {
+  description = "SMTP server hostname for email alert channels"
+  type        = string
+  default     = ""
+}
+
+variable "smtp_port" {
+  description = "SMTP server port"
+  type        = string
+  default     = "587"
+}
+
+variable "smtp_username" {
+  description = "SMTP username"
+  type        = string
+  default     = ""
+}
+
+variable "smtp_password" {
+  description = "SMTP password"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "smtp_from" {
+  description = "From address for alert emails, e.g. 'PulseChecks <alerts@example.com>'"
+  type        = string
+  default     = ""
+}

--- a/infra/gcp/cloudrun.tf
+++ b/infra/gcp/cloudrun.tf
@@ -66,6 +66,33 @@ resource "google_cloud_run_service" "pulsechecks_api" {
           value = "https://${var.domain_name}"
         }
 
+        # SMTP for email alert channels (optional — email channels are
+        # unavailable until these are set)
+        env {
+          name  = "SMTP_HOST"
+          value = var.smtp_host
+        }
+
+        env {
+          name  = "SMTP_PORT"
+          value = var.smtp_port
+        }
+
+        env {
+          name  = "SMTP_USERNAME"
+          value = var.smtp_username
+        }
+
+        env {
+          name  = "SMTP_PASSWORD"
+          value = var.smtp_password
+        }
+
+        env {
+          name  = "SMTP_FROM"
+          value = var.smtp_from
+        }
+
         # Port
         ports {
           container_port = 8080

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -112,3 +112,36 @@ variable "edge_throttle_burst" {
   type        = number
   default     = 2000
 }
+
+# SMTP settings for email alert channels (optional). Leave empty to
+# disable email channels on this deployment.
+variable "smtp_host" {
+  description = "SMTP server hostname for email alert channels"
+  type        = string
+  default     = ""
+}
+
+variable "smtp_port" {
+  description = "SMTP server port"
+  type        = string
+  default     = "587"
+}
+
+variable "smtp_username" {
+  description = "SMTP username"
+  type        = string
+  default     = ""
+}
+
+variable "smtp_password" {
+  description = "SMTP password"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "smtp_from" {
+  description = "From address for alert emails, e.g. 'PulseChecks <alerts@example.com>'"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Follow-up to #48 — the functional and UX gaps from the production-readiness review:

- **Email alert channel (SMTP)**: new `email` channel type delivered over SMTP via stdlib `smtplib` in a worker thread. Cloud-agnostic — SES SMTP on AWS, SendGrid/Mailgun/Workspace relay on GCP (closing the "no email alerts on GCP" gap). `SMTP_*` settings exposed as Terraform variables on both clouds; recipients validated (max 20); test notifications supported; documented in `docs/alert-channels.md`.
- **Telegram delivery implemented**: the send path in `_send_channel_alert` was a TODO stub — Telegram channels were configurable in the UI but silently never sent. Also fixed a latent bug where the recovery path passed `metrics=None`, making metric calls raise after delivery.
- **Dashboard fleet status**: the dashboard now answers "is anything down right now?" — red banner listing late checks across all teams (linked to detail), green all-operational strip, Up/Late/Pending/Paused stat tiles (icon + label, not color-alone), per-team check counts with late indicators, 60s refresh, and grid/list preference persisted.
- **Native dialog migration complete**: reusable `ConfirmDialog` component; zero `alert()`/`confirm()` calls remain. Success toasts added where feedback was missing (invitations, channel CRUD, webhooks, token revocation). Check detail's alert-config header now always shows channel status, including an amber "No channels — alerts disabled" warning. Dead legacy alert-topics code removed.

## Testing

- Backend: 382 passed, 8 skipped (includes new email/Telegram channel tests)
- Frontend: 64 passed, 1 skipped (includes new fleet-status tests); production build verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi)_