### PR TITLE
Durable alert delivery: queue, retries, dead-letter, and alert history

### DIFF
--- a/backend/app/alert_dispatch.py
+++ b/backend/app/alert_dispatch.py
@@ -1,0 +1,192 @@
+"""Durable alert delivery pipeline.
+
+Every alert (late / recovery / escalation) becomes an AlertDelivery record —
+one per target channel — that is both a queue item and a permanent history
+entry. Delivery is attempted immediately where the runtime allows, and any
+failure is retried with exponential backoff by the late-detection scheduler
+run (every 2 minutes) until it succeeds or exhausts max_attempts, at which
+point the record lands in the terminal "failed" state (dead-letter) and a
+metric fires.
+
+This is deliberately database-backed rather than SQS/PubSub so the exact
+same mechanism works on both clouds with zero extra infrastructure.
+"""
+import asyncio
+from typing import List, Optional
+
+from .models import AlertDelivery
+from .utils import generate_id, get_iso_timestamp, get_current_time_seconds
+from .logging_config import get_logger, log_business_event
+from .metrics import get_metrics_client
+
+logger = get_logger(__name__)
+
+# Retry schedule: attempt 1 immediately, then 2m, 4m, 8m, 16m after each
+# failure — five attempts spanning ~30 minutes before dead-lettering.
+BACKOFF_BASE_SECONDS = 120
+MAX_ATTEMPTS = 5
+DELIVERY_CONCURRENCY = 10
+
+
+async def enqueue_check_alerts(
+    db,
+    check,
+    alert_type: str,
+    channel_ids: Optional[List[str]] = None,
+    team=None,
+    attempt_now: bool = True,
+) -> List[AlertDelivery]:
+    """Create delivery records for a check's alert channels.
+
+    With attempt_now=True (scheduler context) each delivery is attempted
+    immediately; failures stay pending and are retried on later runs.
+    With attempt_now=False (request context, e.g. the ping endpoint's
+    recovery path) records are only enqueued, so the request never blocks
+    on outbound notification calls — the next scheduler run (≤2 minutes)
+    delivers them.
+    """
+    ids = channel_ids if channel_ids is not None else (check.alert_channels or [])
+    if not ids:
+        return []
+
+    now = get_current_time_seconds()
+    deliveries = []
+    for channel_id in ids:
+        channel = None
+        try:
+            channel = await db.get_alert_channel(check.team_id, channel_id)
+        except Exception as e:
+            logger.error(f"Failed to resolve channel {channel_id} for check {check.check_id}: {e}")
+
+        delivery = AlertDelivery(
+            delivery_id=generate_id(),
+            team_id=check.team_id,
+            check_id=check.check_id,
+            check_name=check.name,
+            channel_id=channel_id,
+            channel_type=channel.type.value if channel else "unknown",
+            channel_name=channel.display_name if channel else channel_id,
+            alert_type=alert_type,
+            status="pending",
+            attempts=0,
+            max_attempts=MAX_ATTEMPTS,
+            next_attempt_at=now,
+            created_at=get_iso_timestamp(),
+        )
+        if channel is None:
+            # Dead-letter immediately — retrying a nonexistent channel is pointless.
+            delivery.status = "failed"
+            delivery.attempts = MAX_ATTEMPTS
+            delivery.last_error = "Alert channel not found"
+        await db.create_alert_delivery(delivery)
+        deliveries.append(delivery)
+
+    if attempt_now:
+        pending = [d for d in deliveries if d.status == "pending"]
+        semaphore = asyncio.Semaphore(DELIVERY_CONCURRENCY)
+
+        async def _attempt(d):
+            async with semaphore:
+                await process_delivery(db, d, check=check, team=team)
+
+        await asyncio.gather(*(_attempt(d) for d in pending), return_exceptions=True)
+
+    return deliveries
+
+
+async def process_delivery(db, delivery: AlertDelivery, check=None, team=None) -> bool:
+    """Attempt one delivery and persist the outcome. Returns success."""
+    from .handlers import _send_channel_alert  # deferred: avoid import cycle
+
+    metrics = get_metrics_client()
+    now = get_current_time_seconds()
+    delivery.attempts += 1
+    error: Optional[str] = None
+    success = False
+
+    try:
+        if check is None:
+            check = await db.get_check(delivery.team_id, delivery.check_id)
+        if check is None:
+            # Check was deleted since the alert was enqueued — dead-letter.
+            delivery.status = "failed"
+            delivery.last_error = "Check no longer exists"
+            await db.update_alert_delivery(delivery)
+            return False
+
+        if team is None:
+            team = await db.get_team(delivery.team_id)
+
+        channel = await db.get_alert_channel(delivery.team_id, delivery.channel_id)
+        if channel is None:
+            delivery.status = "failed"
+            delivery.last_error = "Alert channel no longer exists"
+            await db.update_alert_delivery(delivery)
+            return False
+
+        success = await _send_channel_alert(
+            channel, check, team, None, metrics, delivery.alert_type
+        )
+        if not success:
+            error = "Channel send reported failure"
+    except Exception as e:
+        error = str(e)[:500]
+        logger.error(
+            f"Delivery {delivery.delivery_id} attempt {delivery.attempts} failed "
+            f"({delivery.channel_type} channel for check {delivery.check_id}): {e}"
+        )
+
+    if success:
+        delivery.status = "delivered"
+        delivery.delivered_at = get_iso_timestamp()
+        delivery.last_error = None
+    else:
+        delivery.last_error = error or "Delivery failed"
+        if delivery.attempts >= delivery.max_attempts:
+            delivery.status = "failed"
+            metrics.increment_counter("AlertDeliveryExhausted", {
+                "ChannelType": delivery.channel_type,
+            })
+            log_business_event(
+                "alert_delivery_exhausted",
+                team_id=delivery.team_id,
+                check_id=delivery.check_id,
+                channel_id=delivery.channel_id,
+                channel_type=delivery.channel_type,
+                alert_type=delivery.alert_type,
+                attempts=delivery.attempts,
+                error=delivery.last_error,
+            )
+        else:
+            backoff = BACKOFF_BASE_SECONDS * (2 ** (delivery.attempts - 1))
+            delivery.next_attempt_at = now + backoff
+
+    await db.update_alert_delivery(delivery)
+    return success
+
+
+async def process_due_deliveries(db, limit: int = 100) -> dict:
+    """Drain due pending deliveries (retries and request-context enqueues).
+
+    Called from every late-detection run, so retries piggyback on the
+    existing 2-minute scheduler on both clouds.
+    """
+    now = get_current_time_seconds()
+    due = await db.query_due_alert_deliveries(now, limit=limit)
+    if not due:
+        return {"processed": 0, "delivered": 0, "failed": 0}
+
+    semaphore = asyncio.Semaphore(DELIVERY_CONCURRENCY)
+    results = []
+
+    async def _attempt(d):
+        async with semaphore:
+            results.append(await process_delivery(db, d))
+
+    await asyncio.gather(*(_attempt(d) for d in due), return_exceptions=True)
+
+    delivered = sum(1 for r in results if r)
+    stats = {"processed": len(due), "delivered": delivered, "failed": len(due) - delivered}
+    if stats["processed"]:
+        logger.info(f"Delivery queue drain: {stats}")
+    return stats

--- a/backend/app/db/dynamodb.py
+++ b/backend/app/db/dynamodb.py
@@ -6,7 +6,7 @@ from botocore.exceptions import ClientError
 from contextlib import asynccontextmanager
 
 from ..config import get_settings
-from ..models import User, Team, TeamMember, Check, Ping, Role, CheckStatus, PendingInvitation, AlertChannel, AlertChannelType, MaintenanceWindow, Report
+from ..models import User, Team, TeamMember, Check, Ping, Role, CheckStatus, PendingInvitation, AlertChannel, AlertChannelType, AlertDelivery, MaintenanceWindow, Report
 from ..errors import PulsechecksError
 from ..utils import get_iso_timestamp, get_current_time_seconds
 from ..utils.retry import with_retry, RetryConfig
@@ -575,6 +575,136 @@ class DynamoDBClient(DatabaseInterface):
             await table.delete_item(
                 Key={"PK": f"TEAM#{team_id}", "SK": f"MAINTENANCE#{window_id}"}
             )
+
+    # Alert delivery queue / history operations
+
+    def _delivery_sk(self, delivery: AlertDelivery) -> str:
+        return f"ALERTDELIV#{delivery.created_at}#{delivery.delivery_id}"
+
+    @staticmethod
+    def _item_to_delivery(item: Dict[str, Any]) -> AlertDelivery:
+        return AlertDelivery(
+            delivery_id=item["deliveryId"],
+            team_id=item["teamId"],
+            check_id=item["checkId"],
+            check_name=item.get("checkName", ""),
+            channel_id=item["channelId"],
+            channel_type=item.get("channelType", ""),
+            channel_name=item.get("channelName", ""),
+            alert_type=item.get("alertType", "late"),
+            status=item.get("deliveryStatus", "pending"),
+            attempts=int(item.get("attempts", 0)),
+            max_attempts=int(item.get("maxAttempts", 5)),
+            next_attempt_at=int(item.get("nextAttemptAt", 0)),
+            last_error=item.get("lastError"),
+            created_at=item["createdAt"],
+            delivered_at=item.get("deliveredAt"),
+        )
+
+    async def create_alert_delivery(self, delivery: AlertDelivery) -> None:
+        """Persist a new alert delivery record."""
+        settings = get_settings()
+        ttl = get_current_time_seconds() + (settings.ping_retention_days * 24 * 60 * 60)
+        item = {
+            "PK": f"TEAM#{delivery.team_id}",
+            "SK": self._delivery_sk(delivery),
+            "deliveryId": delivery.delivery_id,
+            "teamId": delivery.team_id,
+            "checkId": delivery.check_id,
+            "checkName": delivery.check_name,
+            "channelId": delivery.channel_id,
+            "channelType": delivery.channel_type,
+            "channelName": delivery.channel_name,
+            "alertType": delivery.alert_type,
+            "deliveryStatus": delivery.status,
+            "attempts": delivery.attempts,
+            "maxAttempts": delivery.max_attempts,
+            "nextAttemptAt": delivery.next_attempt_at,
+            "createdAt": delivery.created_at,
+            "TTL": ttl,
+        }
+        if delivery.last_error:
+            item["lastError"] = delivery.last_error
+        if delivery.delivered_at:
+            item["deliveredAt"] = delivery.delivered_at
+        if delivery.status == "pending":
+            # Pending deliveries live in the DueIndex under their own
+            # partition so the worker can query them by next_attempt_at.
+            item["GSI1PK"] = "PENDING_DELIVERY"
+            item["GSI1SK"] = delivery.next_attempt_at
+        async with self._get_table() as table:
+            await table.put_item(Item=item)
+
+    async def update_alert_delivery(self, delivery: AlertDelivery) -> None:
+        """Update an alert delivery's status/attempt fields."""
+        set_parts = [
+            "deliveryStatus = :status",
+            "attempts = :attempts",
+            "nextAttemptAt = :next_attempt",
+        ]
+        values = {
+            ":status": delivery.status,
+            ":attempts": delivery.attempts,
+            ":next_attempt": delivery.next_attempt_at,
+        }
+        remove_parts = []
+        if delivery.last_error is not None:
+            set_parts.append("lastError = :err")
+            values[":err"] = delivery.last_error
+        if delivery.delivered_at is not None:
+            set_parts.append("deliveredAt = :delivered")
+            values[":delivered"] = delivery.delivered_at
+        if delivery.status == "pending":
+            set_parts.append("GSI1PK = :gsi1pk")
+            set_parts.append("GSI1SK = :gsi1sk")
+            values[":gsi1pk"] = "PENDING_DELIVERY"
+            values[":gsi1sk"] = delivery.next_attempt_at
+        else:
+            # Terminal state — drop out of the pending index.
+            remove_parts = ["GSI1PK", "GSI1SK"]
+
+        update_expression = "SET " + ", ".join(set_parts)
+        if remove_parts:
+            update_expression += " REMOVE " + ", ".join(remove_parts)
+
+        async with self._get_table() as table:
+            await table.update_item(
+                Key={"PK": f"TEAM#{delivery.team_id}", "SK": self._delivery_sk(delivery)},
+                UpdateExpression=update_expression,
+                ExpressionAttributeValues=values,
+            )
+
+    async def query_due_alert_deliveries(self, current_time_seconds: int, limit: int = 100) -> List[AlertDelivery]:
+        """Query pending deliveries whose next_attempt_at is due."""
+        async with self._get_table() as table:
+            response = await table.query(
+                IndexName="DueIndex",
+                KeyConditionExpression="GSI1PK = :pk AND GSI1SK <= :time",
+                ExpressionAttributeValues={
+                    ":pk": "PENDING_DELIVERY",
+                    ":time": current_time_seconds,
+                },
+                Limit=limit,
+            )
+            return [self._item_to_delivery(item) for item in response.get("Items", [])]
+
+    async def list_alert_deliveries(self, team_id: str, check_id: str | None = None, limit: int = 50) -> List[AlertDelivery]:
+        """List delivery history for a team (optionally one check), newest first."""
+        async with self._get_table() as table:
+            kwargs = {
+                "KeyConditionExpression": "PK = :pk AND begins_with(SK, :sk_prefix)",
+                "ExpressionAttributeValues": {
+                    ":pk": f"TEAM#{team_id}",
+                    ":sk_prefix": "ALERTDELIV#",
+                },
+                "ScanIndexForward": False,
+                "Limit": limit,
+            }
+            if check_id:
+                kwargs["FilterExpression"] = "checkId = :check_id"
+                kwargs["ExpressionAttributeValues"][":check_id"] = check_id
+            response = await table.query(**kwargs)
+            return [self._item_to_delivery(item) for item in response.get("Items", [])]
 
     async def create_report(self, report: Report) -> None:
         """Persist a generated report record."""

--- a/backend/app/db/firestore.py
+++ b/backend/app/db/firestore.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from ..config import get_settings
 from ..models import (
     User, Team, TeamMember, Check, Ping, Role, CheckStatus,
-    PendingInvitation, AlertChannel, AlertChannelType, MaintenanceWindow, Report
+    PendingInvitation, AlertChannel, AlertChannelType, AlertDelivery, MaintenanceWindow, Report
 )
 from ..errors import PulsechecksError
 from ..utils import get_iso_timestamp, get_current_time_seconds
@@ -689,6 +689,85 @@ class FirestoreClient(DatabaseInterface):
         doc_ref = (self.db.collection('teams').document(team_id)
                    .collection('maintenance').document(window_id))
         await doc_ref.delete()
+
+    # Alert delivery queue / history operations
+
+    @staticmethod
+    def _dict_to_delivery(data: Dict[str, Any]) -> AlertDelivery:
+        return AlertDelivery(
+            delivery_id=data['deliveryId'],
+            team_id=data['teamId'],
+            check_id=data['checkId'],
+            check_name=data.get('checkName', ''),
+            channel_id=data['channelId'],
+            channel_type=data.get('channelType', ''),
+            channel_name=data.get('channelName', ''),
+            alert_type=data.get('alertType', 'late'),
+            status=data.get('status', 'pending'),
+            attempts=int(data.get('attempts', 0)),
+            max_attempts=int(data.get('maxAttempts', 5)),
+            next_attempt_at=int(data.get('nextAttemptAt', 0)),
+            last_error=data.get('lastError'),
+            created_at=data['createdAt'],
+            delivered_at=data.get('deliveredAt'),
+        )
+
+    async def create_alert_delivery(self, delivery: AlertDelivery) -> None:
+        """Persist a new alert delivery record."""
+        settings = get_settings()
+        ttl_seconds = get_current_time_seconds() + (settings.ping_retention_days * 24 * 60 * 60)
+        doc_ref = self.db.collection('alertDeliveries').document(delivery.delivery_id)
+        await doc_ref.set({
+            'deliveryId': delivery.delivery_id,
+            'teamId': delivery.team_id,
+            'checkId': delivery.check_id,
+            'checkName': delivery.check_name,
+            'channelId': delivery.channel_id,
+            'channelType': delivery.channel_type,
+            'channelName': delivery.channel_name,
+            'alertType': delivery.alert_type,
+            'status': delivery.status,
+            'attempts': delivery.attempts,
+            'maxAttempts': delivery.max_attempts,
+            'nextAttemptAt': delivery.next_attempt_at,
+            'lastError': delivery.last_error,
+            'createdAt': delivery.created_at,
+            'deliveredAt': delivery.delivered_at,
+            'ttl': datetime.fromtimestamp(ttl_seconds, tz=timezone.utc),
+        })
+
+    async def update_alert_delivery(self, delivery: AlertDelivery) -> None:
+        """Update an alert delivery's status/attempt fields."""
+        doc_ref = self.db.collection('alertDeliveries').document(delivery.delivery_id)
+        await doc_ref.update({
+            'status': delivery.status,
+            'attempts': delivery.attempts,
+            'nextAttemptAt': delivery.next_attempt_at,
+            'lastError': delivery.last_error,
+            'deliveredAt': delivery.delivered_at,
+        })
+
+    async def query_due_alert_deliveries(self, current_time_seconds: int, limit: int = 100) -> List[AlertDelivery]:
+        """Query pending deliveries whose next_attempt_at is due."""
+        query = (self.db.collection('alertDeliveries')
+                 .where('status', '==', 'pending')
+                 .where('nextAttemptAt', '<=', current_time_seconds)
+                 .limit(limit))
+        deliveries = []
+        async for doc in query.stream():
+            deliveries.append(self._dict_to_delivery(doc.to_dict()))
+        return deliveries
+
+    async def list_alert_deliveries(self, team_id: str, check_id: str | None = None, limit: int = 50) -> List[AlertDelivery]:
+        """List delivery history for a team (optionally one check), newest first."""
+        query = self.db.collection('alertDeliveries').where('teamId', '==', team_id)
+        if check_id:
+            query = query.where('checkId', '==', check_id)
+        query = query.order_by('createdAt', direction='DESCENDING').limit(limit)
+        deliveries = []
+        async for doc in query.stream():
+            deliveries.append(self._dict_to_delivery(doc.to_dict()))
+        return deliveries
 
     async def create_report(self, report: Report) -> None:
         """Persist a generated report record."""

--- a/backend/app/db/interface.py
+++ b/backend/app/db/interface.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Dict, Any
 
 from ..models import (
     User, Team, TeamMember, Check, Ping, Role,
-    PendingInvitation, AlertChannel, MaintenanceWindow, Report
+    PendingInvitation, AlertChannel, AlertDelivery, MaintenanceWindow, Report
 )
 
 
@@ -227,6 +227,28 @@ class DatabaseInterface(ABC):
     @abstractmethod
     async def delete_maintenance_window(self, team_id: str, window_id: str) -> None:
         """Delete a maintenance window."""
+        pass
+
+    # Alert delivery queue / history operations
+
+    @abstractmethod
+    async def create_alert_delivery(self, delivery: AlertDelivery) -> None:
+        """Persist a new alert delivery record."""
+        pass
+
+    @abstractmethod
+    async def update_alert_delivery(self, delivery: AlertDelivery) -> None:
+        """Update an alert delivery's status/attempt fields."""
+        pass
+
+    @abstractmethod
+    async def query_due_alert_deliveries(self, current_time_seconds: int, limit: int = 100) -> List[AlertDelivery]:
+        """Query pending deliveries whose next_attempt_at is due."""
+        pass
+
+    @abstractmethod
+    async def list_alert_deliveries(self, team_id: str, check_id: str | None = None, limit: int = 50) -> List[AlertDelivery]:
+        """List delivery history for a team (optionally one check), newest first."""
         pass
 
     @abstractmethod

--- a/backend/app/handlers.py
+++ b/backend/app/handlers.py
@@ -12,6 +12,7 @@ from .config import get_settings
 from .logging_config import get_logger, log_business_event
 from .metrics import get_metrics_client
 from .integrations.mattermost import create_mattermost_client
+from .alert_dispatch import enqueue_check_alerts, process_due_deliveries
 
 logger = get_logger(__name__)
 
@@ -33,14 +34,9 @@ async def _late_detector_impl(event: Dict[str, Any], context: Any) -> Dict[str, 
     due_checks = await db.query_due_checks(current_time, limit=100)
 
     alerts_queued = 0
-    mattermost_alerts_sent = 0
+    alerts_delivered = 0
     escalations_triggered = 0
     alerts_suppressed = 0
-    
-    # Initialize SNS client once if we have checks to process
-    sns_client = None
-    if due_checks:
-        sns_client = boto3.client("sns", region_name=settings.aws_region)
 
     for check in due_checks:
         # Check if alerts are currently suppressed
@@ -65,32 +61,41 @@ async def _late_detector_impl(event: Dict[str, Any], context: Any) -> Dict[str, 
                 await db.suppress_check_alerts(check.team_id, check.check_id, get_iso_timestamp(suppress_until))
                 logger.info(f"Suppressing alerts for check {check.check_id} after {check.consecutive_alert_count} consecutive alerts")
 
-            # Get team info for Mattermost integration
+            # Get team info for alert formatting
             team = await db.get_team(check.team_id)
-            
-            # Send primary alerts (Mattermost + SNS)
-            sns_sent, mattermost_sent = await _send_primary_alerts(check, team, sns_client, metrics)
-            alerts_queued += sns_sent
-            mattermost_alerts_sent += mattermost_sent
+
+            # Enqueue durable deliveries and attempt them immediately;
+            # failures stay pending and are retried with backoff below.
+            deliveries = await enqueue_check_alerts(db, check, "late", team=team)
+            alerts_queued += len(deliveries)
+            alerts_delivered += sum(1 for d in deliveries if d.status == "delivered")
 
         # Check for escalation (even if check was already late)
         if _should_escalate(check, current_time):
             # Trigger escalation
             await db.mark_escalation_triggered(check.team_id, check.check_id, get_iso_timestamp())
-            
+
             # Get team info
             team = await db.get_team(check.team_id)
-            
-            # Send escalated alerts
-            await _send_escalated_alerts(check, team, sns_client, metrics)
+
+            # Enqueue escalated alerts
+            await enqueue_check_alerts(
+                db, check, "escalation",
+                channel_ids=check.escalation_alert_channels, team=team,
+            )
             escalations_triggered += 1
 
+    # Drain the delivery queue: retries with backoff, plus deliveries
+    # enqueued outside scheduler context (e.g. the ping recovery path).
+    drain_stats = await process_due_deliveries(db)
+
     # Record enhanced metrics
-    metrics.late_detection_run(len(due_checks), alerts_queued + mattermost_alerts_sent)
-    log_business_event('enhanced_late_detection_run', 
-        checks_processed=len(due_checks), 
-        sns_alerts_queued=alerts_queued,
-        mattermost_alerts_sent=mattermost_alerts_sent,
+    metrics.late_detection_run(len(due_checks), alerts_queued)
+    log_business_event('enhanced_late_detection_run',
+        checks_processed=len(due_checks),
+        alerts_queued=alerts_queued,
+        alerts_delivered=alerts_delivered,
+        deliveries_retried=drain_stats["processed"],
         escalations_triggered=escalations_triggered,
         alerts_suppressed=alerts_suppressed
     )
@@ -101,7 +106,8 @@ async def _late_detector_impl(event: Dict[str, Any], context: Any) -> Dict[str, 
             {
                 "checksProcessed": len(due_checks),
                 "channelAlertsQueued": alerts_queued,
-                "channelAlertsSent": mattermost_alerts_sent,
+                "channelAlertsSent": alerts_delivered,
+                "deliveriesRetried": drain_stats["processed"],
                 "escalationsTriggered": escalations_triggered,
                 "alertsSuppressed": alerts_suppressed,
             }
@@ -155,33 +161,6 @@ def _should_escalate(check, current_time: int) -> bool:
     return current_time >= escalation_time
 
 
-async def _send_primary_alerts(check, team, sns_client, metrics):
-    """Send primary alerts (Mattermost + SNS + AlertChannels). Returns (sns_sent, mattermost_sent)."""
-    sns_sent = 0
-    mattermost_sent = 0
-    
-    # Legacy Mattermost webhooks removed - use AlertChannels only
-
-    # Send new AlertChannel alerts
-    if check.alert_channels:
-        db = create_db_client()
-        for channel_id in check.alert_channels:
-            try:
-                channel = await db.get_alert_channel(check.team_id, channel_id)
-                if not channel:
-                    logger.warning(f"Alert channel {channel_id} not found for check {check.check_id}")
-                    continue
-                
-                success = await _send_channel_alert(channel, check, team, sns_client, metrics)
-                if success:
-                    logger.info(f"Alert sent via channel {channel.name} ({channel.type.value}) for check {check.check_id}")
-                
-            except Exception as e:
-                logger.error(f"Failed to send alert via channel {channel_id} for check {check.check_id}: {e}")
-    
-    return sns_sent, mattermost_sent
-
-
 async def _send_channel_alert(channel, check, team, sns_client, metrics, alert_type="late"):
     """Send alert via a specific AlertChannel. Returns success boolean."""
     from .models import AlertChannelType
@@ -194,8 +173,11 @@ async def _send_channel_alert(channel, check, team, sns_client, metrics, alert_t
     try:
         if channel.type == AlertChannelType.SNS:
             topic_arn = channel.configuration.get('topic_arn')
-            if not topic_arn or not sns_client:
+            if not topic_arn:
                 return False
+            if sns_client is None:
+                settings = get_settings()
+                sns_client = boto3.client("sns", region_name=settings.aws_region)
                 
             message = {
                 "checkId": check.check_id,
@@ -306,25 +288,6 @@ async def _send_channel_alert(channel, check, team, sns_client, metrics, alert_t
     
     return False
 
-
-async def _send_escalated_alerts(check, team, sns_client, metrics):
-    """Send escalated alerts via AlertChannels only."""
-    # Send escalated alerts via modern AlertChannels
-    if check.escalation_alert_channels:
-        db = create_db_client()
-        for channel_id in check.escalation_alert_channels:
-            try:
-                channel = await db.get_alert_channel(check.team_id, channel_id)
-                if not channel:
-                    logger.warning(f"Escalation alert channel {channel_id} not found for check {check.check_id}")
-                    continue
-                
-                success = await _send_channel_alert(channel, check, team, sns_client, metrics)
-                if success:
-                    logger.info(f"Escalation alert sent via channel {channel.name} ({channel.type.value}) for check {check.check_id}")
-                
-            except Exception as e:
-                logger.error(f"Failed to send escalation alert via channel {channel_id} for check {check.check_id}: {e}")
 
 # Export handlers
 __all__ = ["late_detector_handler"]

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -13,12 +13,21 @@ class MetricsClient:
     
     def __init__(self):
         self.settings = get_settings()
-        self.cloudwatch = boto3.client('cloudwatch', region_name=self.settings.aws_region)
+        # CloudWatch custom metrics are AWS-only. On GCP, observability
+        # comes from structured logs (log_business_event) consumed by
+        # log-based metrics — skip CloudWatch entirely to avoid a failed
+        # (and error-logged) API call on every metric emission.
+        if self.settings.cloud_provider == 'aws':
+            self.cloudwatch = boto3.client('cloudwatch', region_name=self.settings.aws_region)
+        else:
+            self.cloudwatch = None
         self.namespace = 'Pulsechecks'
-    
-    def put_metric(self, metric_name: str, value: float, unit: str = 'Count', 
+
+    def put_metric(self, metric_name: str, value: float, unit: str = 'Count',
                    dimensions: Optional[Dict[str, str]] = None):
         """Put a custom metric to CloudWatch."""
+        if self.cloudwatch is None:
+            return
         try:
             metric_data = {
                 'MetricName': metric_name,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -28,7 +28,7 @@ from .responses import (
     OkResponse,
     AlertTopicResponse,
 )
-from .entities import User, Team, Check, Ping, TeamMember, PendingInvitation, AlertChannel, MaintenanceWindow, Report
+from .entities import User, Team, Check, Ping, TeamMember, PendingInvitation, AlertChannel, AlertDelivery, MaintenanceWindow, Report
 
 __all__ = [
     # Enums
@@ -69,6 +69,7 @@ __all__ = [
     "Team",
     "Check",
     "Ping",
+    "AlertDelivery",
     "MaintenanceWindow",
     "Report",
     "TeamMember",

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -117,6 +117,30 @@ class Ping(BaseModel):
     response_time_ms: Optional[int] = None
 
 
+class AlertDelivery(BaseModel):
+    """One alert delivery to one channel — queue item and history entry.
+
+    Lifecycle: pending → delivered, or pending → (retries with backoff)
+    → failed once attempts reach max_attempts (dead-letter state).
+    """
+
+    delivery_id: str
+    team_id: str
+    check_id: str
+    check_name: str
+    channel_id: str
+    channel_type: str
+    channel_name: str
+    alert_type: str  # late | recovery | escalation
+    status: str = "pending"  # pending | delivered | failed
+    attempts: int = 0
+    max_attempts: int = 5
+    next_attempt_at: int = 0  # epoch seconds; 0 = due immediately
+    last_error: Optional[str] = None
+    created_at: str
+    delivered_at: Optional[str] = None
+
+
 class MaintenanceWindow(BaseModel):
     """Scheduled maintenance window entity."""
 

--- a/backend/app/routers/checks.py
+++ b/backend/app/routers/checks.py
@@ -1,7 +1,7 @@
 """Check management endpoints."""
 from collections import Counter
 import math
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 from fastapi import APIRouter, Depends, Query, status, HTTPException
 
 from ..dependencies import AuthUser, Database, check_team_access
@@ -708,17 +708,15 @@ async def escalate_check_immediately(
     # Mark escalation as triggered
     await db.mark_escalation_triggered(team_id, check_id, get_iso_timestamp())
 
-    # Send escalated alerts immediately
+    # Enqueue escalated alerts (durable delivery with retries)
     try:
-        from ..handlers import _send_escalated_alerts
-        import boto3
-        from ..config import get_settings
+        from ..alert_dispatch import enqueue_check_alerts
 
-        settings = get_settings()
-        sns_client = boto3.client("sns", region_name=settings.aws_region)
         team = await db.get_team(team_id)
-
-        await _send_escalated_alerts(check, team, sns_client, get_metrics_client())
+        await enqueue_check_alerts(
+            db, check, "escalation",
+            channel_ids=check.escalation_alert_channels, team=team,
+        )
 
         return OkResponse(message="Escalation triggered successfully")
     except Exception as e:
@@ -900,3 +898,39 @@ async def get_check_uptime(
     windows = await db.list_maintenance_windows(team_id, check_id)
 
     return _build_check_uptime_response(check, pings, windows, from_at, to_at, exclude_maintenance)
+
+
+@router.get("/{check_id}/alert-history", response_model=List[Dict[str, Any]])
+async def get_check_alert_history(
+    team_id: str,
+    check_id: str,
+    current_user: AuthUser,
+    db: Database,
+    limit: int = Query(default=50, ge=1, le=200),
+) -> List[Dict[str, Any]]:
+    """List alert delivery history for a check, newest first."""
+    await check_team_access(team_id, current_user, db, Permission.VIEW)
+
+    check = await db.get_check(team_id, check_id)
+    if not check:
+        raise NotFoundError("Check not found")
+
+    deliveries = await db.list_alert_deliveries(team_id, check_id=check_id, limit=limit)
+    return [
+        {
+            "deliveryId": d.delivery_id,
+            "checkId": d.check_id,
+            "checkName": d.check_name,
+            "channelId": d.channel_id,
+            "channelType": d.channel_type,
+            "channelName": d.channel_name,
+            "alertType": d.alert_type,
+            "status": d.status,
+            "attempts": d.attempts,
+            "maxAttempts": d.max_attempts,
+            "lastError": d.last_error,
+            "createdAt": d.created_at,
+            "deliveredAt": d.delivered_at,
+        }
+        for d in deliveries
+    ]

--- a/backend/app/routers/ping.py
+++ b/backend/app/routers/ping.py
@@ -159,15 +159,17 @@ async def _record_ping_internal(
                 },
             )
 
-        # Send recovery alert if check was late and is now up
-        if was_late and ping_type == PingType.SUCCESS:
+        # Enqueue recovery alerts if check was late and is now up.
+        # Enqueue-only (attempt_now=False): the ping request must never
+        # block on outbound notification calls. The late-detection
+        # scheduler drains the queue within ~2 minutes.
+        if was_late and ping_type == PingType.SUCCESS and check.alert_channels:
             try:
-                await _send_recovery_alert_async(check)
-                metrics.alert_sent(check.team_id, check.check_id, 'recovery', True)
+                from ..alert_dispatch import enqueue_check_alerts
+                await enqueue_check_alerts(check=check, db=db, alert_type="recovery", attempt_now=False)
             except Exception as e:
-                logger.error(f"Recovery alert failed for check {check.check_id}: {e}")
-                metrics.alert_sent(check.team_id, check.check_id, 'recovery', False)
-                # Continue - don't let alert failure break the ping
+                logger.error(f"Failed to enqueue recovery alerts for check {check.check_id}: {e}")
+                # Continue - don't let enqueue failure break the ping
 
         message = "Ping recorded" if ping_type == PingType.SUCCESS else "Failure recorded"
         return OkResponse(message=message)
@@ -176,40 +178,6 @@ async def _record_ping_internal(
         metrics.ping_received(check.team_id, check.check_id, True)
         log_business_event('ping_received_paused', team_id=check.team_id, check_id=check.check_id)
         return OkResponse(message="Ping recorded (check is paused)")
-
-
-async def _send_recovery_alert_async(check):
-    """Send recovery alert via AlertChannels only."""
-    try:
-        from ..db import create_db_client
-        db = create_db_client()
-
-        # Get team info for alert channels
-        team = await db.get_team(check.team_id)
-
-        # Send recovery alerts via modern AlertChannels only
-        if check.alert_channels:
-            for channel_id in check.alert_channels:
-                try:
-                    channel = await db.get_alert_channel(check.team_id, channel_id)
-                    if not channel:
-                        logger.warning(f"Recovery alert channel {channel_id} not found for check {check.check_id}")
-                        continue
-
-                    # Send recovery alert via the channel
-                    from ..handlers import _send_channel_alert
-                    success = await _send_channel_alert(channel, check, team, None, None, "recovery")
-                    if success:
-                        logger.info(f"Recovery alert sent via channel {channel.name} ({channel.type.value}) for check {check.check_id}")
-
-                except Exception as e:
-                    logger.error(f"Failed to send recovery alert via channel {channel_id} for check {check.check_id}: {e}")
-        else:
-            logger.info(f"No alert channels configured for check {check.check_id} - no recovery alert sent")
-
-    except Exception as e:
-        logger.error(f"Error in _send_recovery_alert_async: {e}")
-        raise  # Re-raise so the caller can handle it
 
 
 @router.get("/{token}", response_model=OkResponse)

--- a/backend/firestore.indexes.json
+++ b/backend/firestore.indexes.json
@@ -1,6 +1,43 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "alertDeliveries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "nextAttemptAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "alertDeliveries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "teamId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "alertDeliveries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "teamId", "order": "ASCENDING" },
+        { "fieldPath": "checkId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": [
+    {
+      "collectionGroup": "alertDeliveries",
+      "fieldPath": "ttl",
+      "ttl": true,
+      "indexes": [
+        {
+          "queryScope": "COLLECTION",
+          "order": "ASCENDING"
+        }
+      ]
+    },
     {
       "collectionGroup": "pings",
       "fieldPath": "ttl",

--- a/backend/tests/test_advanced_alerting.py
+++ b/backend/tests/test_advanced_alerting.py
@@ -284,11 +284,14 @@ class TestAdvancedAlertingIntegration:
                     mock_current_time.return_value = get_current_time_seconds()  # Current time
                     with patch('app.handlers.get_metrics_client') as mock_metrics:
                         with patch('boto3.client') as mock_boto_client:
-                            with patch('app.handlers._send_escalated_alerts') as mock_escalate:
-                                result = await _late_detector_impl({}, None)
-                                
-                                # Should trigger escalation
-                                assert result["statusCode"] == 200
-                                body = eval(result["body"])
-                                assert body["escalationsTriggered"] == 1
-                                mock_escalate.assert_called_once()
+                            with patch('app.handlers.enqueue_check_alerts', new=AsyncMock(return_value=[])) as mock_enqueue:
+                                with patch('app.handlers.process_due_deliveries', new=AsyncMock(return_value={"processed": 0, "delivered": 0, "failed": 0})):
+                                    result = await _late_detector_impl({}, None)
+
+                                    # Should trigger escalation
+                                    assert result["statusCode"] == 200
+                                    body = eval(result["body"])
+                                    assert body["escalationsTriggered"] == 1
+                                    # Enqueued both the late alert and the escalation
+                                    alert_types = [c.args[2] for c in mock_enqueue.call_args_list]
+                                    assert "escalation" in alert_types

--- a/backend/tests/test_alert_dispatch.py
+++ b/backend/tests/test_alert_dispatch.py
@@ -1,0 +1,176 @@
+"""Tests for the durable alert delivery pipeline."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.alert_dispatch import (
+    enqueue_check_alerts,
+    process_delivery,
+    process_due_deliveries,
+    BACKOFF_BASE_SECONDS,
+    MAX_ATTEMPTS,
+)
+from app.models import AlertChannel, AlertChannelType, AlertDelivery, Check, CheckStatus, Team
+
+
+def _check(channels=("chan-1",)):
+    return Check(
+        check_id="check-1", team_id="team-1", name="Nightly Backup",
+        token="tok", period_seconds=3600, grace_seconds=300,
+        status=CheckStatus.LATE, created_at="2026-01-01T00:00:00Z",
+        alert_channels=list(channels),
+    )
+
+
+def _team():
+    return Team(team_id="team-1", name="SRE", slug="sre",
+                created_at="2026-01-01T00:00:00Z", created_by="user-1")
+
+
+def _channel(channel_id="chan-1"):
+    return AlertChannel(
+        channel_id=channel_id, team_id="team-1", name="oncall",
+        display_name="On-call", type=AlertChannelType.MATTERMOST,
+        configuration={"webhook_url": "https://chat.example.com/hooks/x"},
+        shared=False, created_at="2026-01-01T00:00:00Z", created_by="user-1",
+    )
+
+
+def _delivery(attempts=0, max_attempts=MAX_ATTEMPTS):
+    return AlertDelivery(
+        delivery_id="del-1", team_id="team-1", check_id="check-1",
+        check_name="Nightly Backup", channel_id="chan-1",
+        channel_type="mattermost", channel_name="On-call",
+        alert_type="late", status="pending", attempts=attempts,
+        max_attempts=max_attempts, next_attempt_at=0,
+        created_at="2026-01-01T00:00:00Z",
+    )
+
+
+class TestEnqueue:
+    @pytest.mark.asyncio
+    async def test_enqueue_only_creates_pending_records(self):
+        db = AsyncMock()
+        db.get_alert_channel.return_value = _channel()
+
+        deliveries = await enqueue_check_alerts(db, _check(), "recovery", attempt_now=False)
+
+        assert len(deliveries) == 1
+        assert deliveries[0].status == "pending"
+        assert deliveries[0].alert_type == "recovery"
+        assert deliveries[0].channel_name == "On-call"
+        db.create_alert_delivery.assert_called_once()
+        db.update_alert_delivery.assert_not_called()  # no attempt made
+
+    @pytest.mark.asyncio
+    async def test_enqueue_with_no_channels_is_noop(self):
+        db = AsyncMock()
+        deliveries = await enqueue_check_alerts(db, _check(channels=()), "late")
+        assert deliveries == []
+        db.create_alert_delivery.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_channel_dead_letters_immediately(self):
+        db = AsyncMock()
+        db.get_alert_channel.return_value = None
+
+        deliveries = await enqueue_check_alerts(db, _check(), "late", attempt_now=False)
+
+        assert deliveries[0].status == "failed"
+        assert "not found" in deliveries[0].last_error
+
+    @pytest.mark.asyncio
+    async def test_attempt_now_delivers(self):
+        db = AsyncMock()
+        db.get_alert_channel.return_value = _channel()
+
+        with patch("app.handlers._send_channel_alert", new=AsyncMock(return_value=True)):
+            deliveries = await enqueue_check_alerts(db, _check(), "late", team=_team())
+
+        assert deliveries[0].status == "delivered"
+        assert deliveries[0].attempts == 1
+        assert deliveries[0].delivered_at is not None
+
+
+class TestRetrySemantics:
+    @pytest.mark.asyncio
+    async def test_failure_schedules_exponential_backoff(self):
+        db = AsyncMock()
+        db.get_alert_channel.return_value = _channel()
+        delivery = _delivery(attempts=0)
+
+        with patch("app.handlers._send_channel_alert", new=AsyncMock(return_value=False)), \
+             patch("app.alert_dispatch.get_current_time_seconds", return_value=1000):
+            ok = await process_delivery(db, delivery, check=_check(), team=_team())
+
+        assert ok is False
+        assert delivery.status == "pending"
+        assert delivery.attempts == 1
+        assert delivery.next_attempt_at == 1000 + BACKOFF_BASE_SECONDS  # 2 minutes
+
+        # Second failure doubles the backoff
+        with patch("app.handlers._send_channel_alert", new=AsyncMock(return_value=False)), \
+             patch("app.alert_dispatch.get_current_time_seconds", return_value=2000):
+            await process_delivery(db, delivery, check=_check(), team=_team())
+
+        assert delivery.attempts == 2
+        assert delivery.next_attempt_at == 2000 + BACKOFF_BASE_SECONDS * 2
+
+    @pytest.mark.asyncio
+    async def test_exhausted_attempts_dead_letter(self):
+        db = AsyncMock()
+        db.get_alert_channel.return_value = _channel()
+        delivery = _delivery(attempts=MAX_ATTEMPTS - 1)
+
+        with patch("app.handlers._send_channel_alert", new=AsyncMock(return_value=False)):
+            ok = await process_delivery(db, delivery, check=_check(), team=_team())
+
+        assert ok is False
+        assert delivery.status == "failed"  # dead-letter state
+        assert delivery.attempts == MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_exception_counts_as_failed_attempt(self):
+        db = AsyncMock()
+        db.get_alert_channel.return_value = _channel()
+        delivery = _delivery()
+
+        with patch("app.handlers._send_channel_alert", new=AsyncMock(side_effect=RuntimeError("boom"))):
+            ok = await process_delivery(db, delivery, check=_check(), team=_team())
+
+        assert ok is False
+        assert delivery.status == "pending"
+        assert "boom" in delivery.last_error
+
+    @pytest.mark.asyncio
+    async def test_deleted_check_dead_letters(self):
+        db = AsyncMock()
+        db.get_check.return_value = None
+        delivery = _delivery()
+
+        ok = await process_delivery(db, delivery)
+
+        assert ok is False
+        assert delivery.status == "failed"
+        assert "no longer exists" in delivery.last_error
+
+
+class TestQueueDrain:
+    @pytest.mark.asyncio
+    async def test_drain_processes_due_deliveries(self):
+        db = AsyncMock()
+        db.query_due_alert_deliveries.return_value = [_delivery(), _delivery()]
+        db.get_check.return_value = _check()
+        db.get_team.return_value = _team()
+        db.get_alert_channel.return_value = _channel()
+
+        with patch("app.handlers._send_channel_alert", new=AsyncMock(return_value=True)):
+            stats = await process_due_deliveries(db)
+
+        assert stats == {"processed": 2, "delivered": 2, "failed": 0}
+
+    @pytest.mark.asyncio
+    async def test_drain_with_empty_queue(self):
+        db = AsyncMock()
+        db.query_due_alert_deliveries.return_value = []
+        stats = await process_due_deliveries(db)
+        assert stats["processed"] == 0

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1312,7 +1312,8 @@ def test_escalate_check_immediately(mock_create_db, mock_verify, client, mock_us
     mock_db.get_check.return_value = mock_check
     mock_db.get_team.return_value = MagicMock(name="Test Team")
 
-    with patch("app.handlers._send_escalated_alerts") as mock_escalate:
+    with patch("app.routers.checks.get_metrics_client"), \
+         patch("app.alert_dispatch.enqueue_check_alerts", new=AsyncMock(return_value=[])):
         response = client.post(
             "/teams/team-123/checks/check-456/escalate",
             headers={"Authorization": f"Bearer {mock_jwt_token}"}
@@ -1602,3 +1603,70 @@ def test_bulk_operations_empty_check_ids(mock_create_db, mock_verify, client, mo
 
     assert response.status_code == 200
     assert "Paused 0 of 0 checks" in response.json()["message"]
+
+
+@patch('app.dependencies.create_db_client')
+@patch("app.dependencies.verify_jwt_token")
+def test_get_check_alert_history(mock_verify, mock_create_db, client, mock_jwt_token):
+    """Alert history endpoint returns delivery records newest first."""
+    from app.models import AlertDelivery
+
+    mock_verify.return_value = {
+        "sub": "user-123",
+        "email": "test@example.com",
+        "email_verified": True,
+        "name": "Test User",
+    }
+
+    mock_db = MagicMock()
+    mock_create_db.return_value = mock_db
+    mock_db.get_team_member = AsyncMock(return_value=TeamMember(
+        team_id="team-123",
+        user_id="user-123",
+        role=Role.MEMBER,
+        joined_at="2025-01-01T00:00:00Z",
+    ))
+    mock_db.get_check = AsyncMock(return_value=Check(
+        check_id="check-123",
+        team_id="team-123",
+        name="Test Check",
+        token="test-token",
+        period_seconds=300,
+        grace_seconds=60,
+        status=CheckStatus.LATE,
+        created_at="2025-01-01T00:00:00Z",
+    ))
+    mock_db.list_alert_deliveries = AsyncMock(return_value=[
+        AlertDelivery(
+            delivery_id="del-1", team_id="team-123", check_id="check-123",
+            check_name="Test Check", channel_id="chan-1",
+            channel_type="mattermost", channel_name="On-call",
+            alert_type="late", status="delivered", attempts=1,
+            next_attempt_at=0, created_at="2026-01-01T00:02:00Z",
+            delivered_at="2026-01-01T00:02:01Z",
+        ),
+        AlertDelivery(
+            delivery_id="del-2", team_id="team-123", check_id="check-123",
+            check_name="Test Check", channel_id="chan-2",
+            channel_type="email", channel_name="SRE Email",
+            alert_type="late", status="failed", attempts=5,
+            next_attempt_at=0, last_error="SMTP timeout",
+            created_at="2026-01-01T00:00:00Z",
+        ),
+    ])
+
+    response = client.get(
+        "/teams/team-123/checks/check-123/alert-history",
+        headers={"Authorization": f"Bearer {mock_jwt_token}"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["deliveryId"] == "del-1"
+    assert data[0]["status"] == "delivered"
+    assert data[0]["channelName"] == "On-call"
+    assert data[1]["status"] == "failed"
+    assert data[1]["lastError"] == "SMTP timeout"
+    assert data[1]["attempts"] == 5
+    mock_db.list_alert_deliveries.assert_called_once_with("team-123", check_id="check-123", limit=50)

--- a/backend/tests/test_handlers.py
+++ b/backend/tests/test_handlers.py
@@ -5,7 +5,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from botocore.exceptions import ClientError
 
 from app.handlers import late_detector_handler
-from app.models import Check, CheckStatus
+from app.models import Check, CheckStatus, AlertChannel, AlertChannelType
+
+
+def _sample_channel():
+    return AlertChannel(
+        channel_id="test-channel-id",
+        team_id="team-123",
+        name="test-channel",
+        display_name="Test Channel",
+        type=AlertChannelType.MATTERMOST,
+        configuration={"webhook_url": "https://chat.example.com/hooks/x"},
+        shared=False,
+        created_at="2023-01-01T00:00:00Z",
+        created_by="user-1",
+    )
 
 
 @pytest.fixture
@@ -129,20 +143,29 @@ class TestLateDetectorHandler:
         mock_db = AsyncMock()
         mock_db.query_due_checks.return_value = [sample_check]
         mock_db.update_check_to_late.return_value = True  # Successfully went late
+        mock_db.get_alert_channel.return_value = _sample_channel()
+        mock_db.query_due_alert_deliveries.return_value = []
         mock_create_db.return_value = mock_db
 
         mock_sns = MagicMock()
         mock_boto3.return_value = mock_sns
 
-        # Execute handler
-        result = late_detector_handler(eventbridge_event, lambda_context)
+        # Execute handler with channel send succeeding
+        with patch("app.handlers._send_channel_alert", new=AsyncMock(return_value=True)):
+            result = late_detector_handler(eventbridge_event, lambda_context)
 
         # Verify result
         assert result["statusCode"] == 200
         body = json.loads(result["body"])
         assert body["checksProcessed"] == 1
-        assert body["channelAlertsQueued"] == 0  # No channels - using modern alert channels only
-        assert body["channelAlertsSent"] == 0  # No channels configured
+        assert body["channelAlertsQueued"] == 1  # One delivery record enqueued
+        assert body["channelAlertsSent"] == 1    # Delivered on first attempt
+
+        # A durable delivery record was created and marked delivered
+        mock_db.create_alert_delivery.assert_called_once()
+        mock_db.update_alert_delivery.assert_called_once()
+        updated = mock_db.update_alert_delivery.call_args[0][0]
+        assert updated.status == "delivered"
 
         # Verify database operations
         mock_db.query_due_checks.assert_called_once_with(1672531200, limit=100)
@@ -170,6 +193,7 @@ class TestLateDetectorHandler:
         mock_db = AsyncMock()
         mock_db.query_due_checks.return_value = [sample_check]
         mock_db.update_check_to_late.return_value = False  # Already late
+        mock_db.query_due_alert_deliveries.return_value = []
         mock_create_db.return_value = mock_db
 
         mock_sns = MagicMock()
@@ -206,23 +230,29 @@ class TestLateDetectorHandler:
         mock_db = AsyncMock()
         mock_db.query_due_checks.return_value = [sample_check]
         mock_db.update_check_to_late.return_value = True
+        mock_db.get_alert_channel.return_value = _sample_channel()
+        mock_db.query_due_alert_deliveries.return_value = []
         mock_create_db.return_value = mock_db
 
         mock_sns = MagicMock()
-        mock_sns.publish.side_effect = ClientError(
-            {'Error': {'Code': 'InvalidParameter'}}, 'Publish'
-        )
         mock_boto3.return_value = mock_sns
 
-        # Execute handler (should not raise exception)
-        result = late_detector_handler(eventbridge_event, lambda_context)
+        # Execute handler with channel send failing (should not raise)
+        with patch("app.handlers._send_channel_alert", new=AsyncMock(return_value=False)):
+            result = late_detector_handler(eventbridge_event, lambda_context)
 
         # Verify result
         assert result["statusCode"] == 200
         body = json.loads(result["body"])
         assert body["checksProcessed"] == 1
-        assert body["channelAlertsQueued"] == 0  # Failed to queue alert
-        assert body["channelAlertsSent"] == 0
+        assert body["channelAlertsQueued"] == 1  # Enqueued durably
+        assert body["channelAlertsSent"] == 0    # First attempt failed
+
+        # Delivery stays pending with a retry scheduled via backoff
+        updated = mock_db.update_alert_delivery.call_args[0][0]
+        assert updated.status == "pending"
+        assert updated.attempts == 1
+        assert updated.next_attempt_at > 0
 
     @patch('app.handlers.get_settings')
     @patch('app.handlers.create_db_client')

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -51,6 +51,31 @@ curl -X POST https://api.pulsechecks.example.com/ping/test-token \
   -d "Health check test"
 ```
 
+## Alert Delivery Pipeline
+
+Every alert (late / recovery / escalation) is written as a durable
+`AlertDelivery` record before any notification is attempted — one record per
+target channel. The record is both the queue item and the permanent history
+entry shown in the check's "Alert History" section.
+
+**Lifecycle:**
+- `pending` — enqueued; attempted immediately in scheduler context, or picked
+  up by the next late-detection run (≤2 minutes) when enqueued from the ping
+  endpoint's recovery path (which never blocks on outbound calls).
+- Failed attempts retry with exponential backoff: 2m, 4m, 8m, 16m after each
+  failure — 5 attempts spanning ~30 minutes.
+- `delivered` — terminal success, with `deliveredAt`.
+- `failed` — terminal dead-letter state after `maxAttempts` (or immediately
+  if the channel/check no longer exists), with `lastError` preserved.
+
+**Monitoring:** each exhausted delivery emits the `AlertDeliveryExhausted`
+metric (dimension: `ChannelType`) and an `alert_delivery_exhausted` business
+log event. Alarm on this metric — it means a user did not get an alert they
+configured.
+
+**Retention:** delivery records expire with the same TTL as pings
+(`PING_RETENTION_DAYS`, default 90 days).
+
 ## Troubleshooting
 
 ### Common Issues

--- a/frontend/src/__tests__/CheckDetailPage.test.jsx
+++ b/frontend/src/__tests__/CheckDetailPage.test.jsx
@@ -20,6 +20,7 @@ vi.mock('../lib/api', () => ({
     listAlertChannels: vi.fn(),
     listTeams: vi.fn(),
     updateCheck: vi.fn(),
+    getCheckAlertHistory: vi.fn().mockResolvedValue([]),
   }
 }))
 

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -202,6 +202,11 @@ class ApiClient {
     return this.request(`/teams/${team_id}/checks/${check_id}/stats?${params}`)
   }
 
+  async getCheckAlertHistory(team_id, check_id, limit = 50) {
+    const params = new URLSearchParams({ limit })
+    return this.request(`/teams/${team_id}/checks/${check_id}/alert-history?${params}`)
+  }
+
   async getCheckErrorSummary(team_id, check_id, range = '24h') {
     const params = new URLSearchParams({ range })
     return this.request(`/teams/${team_id}/checks/${check_id}/errors/summary?${params}`)

--- a/frontend/src/pages/CheckDetailPage.jsx
+++ b/frontend/src/pages/CheckDetailPage.jsx
@@ -74,6 +74,7 @@ export default function CheckDetailPage({ user, onLogout }) {
   const [selectedPing, setSelectedPing] = useState(null)
   const [showTokenRotated, setShowTokenRotated] = useState(false)
   const [confirmState, setConfirmState] = useState(null)
+  const [alertHistory, setAlertHistory] = useState([])
   const [availableTopics, setAvailableTopics] = useState([])
   const [availableChannels, setAvailableChannels] = useState([])
   const [teamSlug, setTeamSlug] = useState(null)
@@ -143,6 +144,16 @@ export default function CheckDetailPage({ user, onLogout }) {
     } catch {
     } finally {
       setLoading(false)
+    }
+    loadAlertHistory()
+  }
+
+  async function loadAlertHistory() {
+    try {
+      const history = await api.getCheckAlertHistory(teamId, checkId, 25)
+      setAlertHistory(Array.isArray(history) ? history : [])
+    } catch {
+      setAlertHistory([])
     }
   }
 
@@ -1199,6 +1210,69 @@ export default function CheckDetailPage({ user, onLogout }) {
               </div>
             </div>
           )}
+        </div>
+
+        {/* Alert Delivery History */}
+        <div className="bg-white shadow overflow-hidden sm:rounded-lg">
+          <div className="px-4 py-5 sm:px-6">
+            <h3 className="text-lg leading-6 font-medium text-gray-900 flex items-center">
+              <Bell className="h-5 w-5 mr-2" />
+              Alert History
+            </h3>
+            <p className="mt-1 max-w-2xl text-sm text-gray-500">
+              Every notification sent (or attempted) for this check
+            </p>
+          </div>
+          <div className="border-t border-gray-200">
+            {alertHistory.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-gray-500">
+                No alerts sent yet — that's a good sign
+              </div>
+            ) : (
+              <ul className="divide-y divide-gray-200">
+                {alertHistory.map((entry) => (
+                  <li key={entry.deliveryId} className="px-4 py-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center space-x-3">
+                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          entry.alertType === 'recovery'
+                            ? 'bg-green-100 text-green-800'
+                            : entry.alertType === 'escalation'
+                              ? 'bg-purple-100 text-purple-800'
+                              : 'bg-red-100 text-red-800'
+                        }`}>
+                          {entry.alertType.toUpperCase()}
+                        </span>
+                        <span className="text-sm text-gray-900">
+                          {entry.channelName}
+                          <span className="ml-1 text-gray-500">({entry.channelType})</span>
+                        </span>
+                      </div>
+                      <div className="flex items-center space-x-3">
+                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          entry.status === 'delivered'
+                            ? 'bg-green-100 text-green-800'
+                            : entry.status === 'pending'
+                              ? 'bg-amber-100 text-amber-800'
+                              : 'bg-red-100 text-red-800'
+                        }`}>
+                          {entry.status === 'pending' ? `RETRYING (${entry.attempts}/${entry.maxAttempts})` : entry.status.toUpperCase()}
+                        </span>
+                        <span className="text-sm text-gray-500" title={new Date(entry.createdAt).toLocaleString()}>
+                          {formatDistanceToNow(new Date(entry.createdAt), { addSuffix: true })}
+                        </span>
+                      </div>
+                    </div>
+                    {entry.status === 'failed' && entry.lastError && (
+                      <p className="mt-1 text-xs text-red-600">
+                        Failed after {entry.attempts} {entry.attempts === 1 ? 'attempt' : 'attempts'}: {entry.lastError}
+                      </p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </div>
 
         <div className="bg-white shadow overflow-hidden sm:rounded-lg">

--- a/infra/aws/cloudwatch.tf
+++ b/infra/aws/cloudwatch.tf
@@ -183,3 +183,19 @@ resource "aws_cloudwatch_dashboard" "main" {
     ]
   })
 }
+
+# Alarm when an alert delivery exhausts all retries (dead-letter) —
+# this means a user did not receive an alert they configured.
+resource "aws_cloudwatch_metric_alarm" "alert_delivery_exhausted" {
+  alarm_name          = "pulsechecks-alert-delivery-exhausted-${var.environment}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "AlertDeliveryExhausted"
+  namespace           = "Pulsechecks"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "An alert delivery failed permanently after all retries"
+  alarm_actions       = [aws_sns_topic.alarms.arn]
+}

--- a/infra/gcp/firestore.tf
+++ b/infra/gcp/firestore.tf
@@ -27,5 +27,73 @@ resource "google_firestore_field" "ping_ttl" {
   depends_on = [google_firestore_database.pulsechecks]
 }
 
+# TTL Policy for alert delivery history (same retention as pings)
+resource "google_firestore_field" "alert_delivery_ttl" {
+  project    = var.gcp_project_id
+  database   = google_firestore_database.pulsechecks.name
+  collection = "alertDeliveries"
+  field      = "ttl"
+
+  ttl_config {}
+
+  depends_on = [google_firestore_database.pulsechecks]
+}
+
+# Composite indexes for the alert delivery queue and history queries
+resource "google_firestore_index" "alert_deliveries_pending" {
+  project    = var.gcp_project_id
+  database   = google_firestore_database.pulsechecks.name
+  collection = "alertDeliveries"
+
+  fields {
+    field_path = "status"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "nextAttemptAt"
+    order      = "ASCENDING"
+  }
+
+  depends_on = [google_firestore_database.pulsechecks]
+}
+
+resource "google_firestore_index" "alert_deliveries_team_history" {
+  project    = var.gcp_project_id
+  database   = google_firestore_database.pulsechecks.name
+  collection = "alertDeliveries"
+
+  fields {
+    field_path = "teamId"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "createdAt"
+    order      = "DESCENDING"
+  }
+
+  depends_on = [google_firestore_database.pulsechecks]
+}
+
+resource "google_firestore_index" "alert_deliveries_check_history" {
+  project    = var.gcp_project_id
+  database   = google_firestore_database.pulsechecks.name
+  collection = "alertDeliveries"
+
+  fields {
+    field_path = "teamId"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "checkId"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "createdAt"
+    order      = "DESCENDING"
+  }
+
+  depends_on = [google_firestore_database.pulsechecks]
+}
+
 # Single-field indexes for token/teamId/alertAfterAt are managed by Firestore automatically.
 # Add google_firestore_index resources only for true composite index requirements.

--- a/infra/gcp/monitoring.tf
+++ b/infra/gcp/monitoring.tf
@@ -180,3 +180,42 @@ resource "google_monitoring_alert_policy" "high_latency" {
 #     value_type  = "INT64"
 #   }
 # }
+
+# Log-based metric: alert deliveries that exhausted all retries (dead-letter).
+# Emitted as a structured business event by the backend.
+resource "google_logging_metric" "alert_delivery_exhausted" {
+  project = var.gcp_project_id
+  name    = "pulsechecks-alert-delivery-exhausted"
+  filter  = "resource.type=\"cloud_run_revision\" resource.labels.service_name=\"${google_cloud_run_service.pulsechecks_api.name}\" jsonPayload.event_type=\"alert_delivery_exhausted\""
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+  }
+}
+
+# Alert when any delivery dead-letters — a user did not receive an alert
+# they configured.
+resource "google_monitoring_alert_policy" "alert_delivery_exhausted" {
+  display_name = "Pulsechecks Alert Delivery Exhausted - ${var.environment}"
+  combiner     = "OR"
+  conditions {
+    display_name = "Alert delivery dead-lettered"
+    condition_threshold {
+      filter          = "resource.type=\"cloud_run_revision\" metric.type=\"logging.googleapis.com/user/${google_logging_metric.alert_delivery_exhausted.name}\""
+      duration        = "0s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_SUM"
+      }
+    }
+  }
+
+  notification_channels = [] # Add notification channels if desired
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+}


### PR DESCRIPTION
## Summary

First item of the reliability roadmap: alerts were fire-and-forget — one attempt, sent inline in the late detector (sequentially) and even inline in the ping request for recovery alerts. A transient Mattermost/SMTP/webhook blip silently lost the alert, and nothing recorded whether a notification was ever delivered.

**Every alert (late / recovery / escalation) is now a durable `AlertDelivery` record** — one per target channel — that is both the queue item and the permanent history entry:

- **Enqueue before send**: records are persisted first, then attempted with bounded concurrency (10) in scheduler context.
- **Ping path fully decoupled**: recovery alerts are enqueue-only; the ping request never blocks on outbound notification calls. The next late-detection run (≤2 min) delivers them.
- **Retries with exponential backoff**: 2m → 4m → 8m → 16m, five attempts (~30 min), drained by every late-detection run. Database-backed rather than SQS/Pub/Sub, so the identical mechanism works on both clouds with zero new infrastructure.
- **Dead-letter state**: exhausted deliveries become terminal `failed` with the error preserved, emit an `AlertDeliveryExhausted` metric, and now alarm on both clouds (CloudWatch alarm; GCP log-based metric + alert policy).
- **Storage**: DynamoDB pending deliveries reuse the existing DueIndex under their own partition; Firestore gets an `alertDeliveries` collection with composite indexes and TTL (`PING_RETENTION_DAYS`, matching pings).

**Usability**: new `GET .../checks/{id}/alert-history` endpoint and an **Alert History** section on the check detail page — every notification sent or attempted, with status (delivered / retrying N/M / failed), channel, and failure reason. This answers "did PulseChecks actually notify us at 03:00?"

Also fixed along the way: the metrics client no longer attempts CloudWatch calls on GCP deployments (it was logging an error traceback on every metric emission); the manual `/escalate` endpoint now enqueues durably; the replaced inline-send helpers were removed.

## Testing

- Backend: 393 passed, 8 skipped — includes 10 new dispatch tests (backoff schedule, dead-letter on exhaustion/missing channel/deleted check, queue drain) and an alert-history endpoint test
- Frontend: 64 passed, 1 skipped; production build verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi)_