### PR TITLE
Roadmap items 2–6: tags/search, escalation UI, poller fixes, audit log, multi-region plan

### DIFF
--- a/backend/app/audit.py
+++ b/backend/app/audit.py
@@ -1,0 +1,37 @@
+"""Audit log helper — records who did what, without ever breaking the request."""
+from typing import Optional
+
+from .models import AuditEvent
+from .utils import generate_id, get_iso_timestamp
+from .logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def record_audit(
+    db,
+    team_id: str,
+    actor,
+    action: str,
+    target_type: str,
+    target_id: str,
+    target_name: Optional[str] = None,
+    detail: Optional[str] = None,
+) -> None:
+    """Persist an audit event. Best effort: failures are logged, never raised,
+    so an audit-store hiccup can't fail the underlying admin action."""
+    try:
+        await db.create_audit_event(AuditEvent(
+            event_id=generate_id(),
+            team_id=team_id,
+            actor_id=getattr(actor, "user_id", "unknown"),
+            actor_email=getattr(actor, "email", "unknown"),
+            action=action,
+            target_type=target_type,
+            target_id=target_id,
+            target_name=target_name,
+            detail=detail,
+            created_at=get_iso_timestamp(),
+        ))
+    except Exception as e:
+        logger.error(f"Failed to record audit event {action} for team {team_id}: {e}")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,6 +33,12 @@ class Settings(BaseSettings):
     environment: str = "production"
     debug: bool = False
     ping_retention_days: int = 90
+
+    # Dead-man's-switch: external heartbeat URL pinged after every
+    # successful late-detection run. Point this at an independent
+    # monitor (e.g. a healthchecks.io check) so you find out when
+    # PulseChecks' own detection loop stops running.
+    heartbeat_url: str = ""
     frontend_url: str = "https://pulsechecks.example.com"
 
     # SMTP (email alert channels — cloud-agnostic; use SES SMTP on AWS,

--- a/backend/app/db/dynamodb.py
+++ b/backend/app/db/dynamodb.py
@@ -6,7 +6,7 @@ from botocore.exceptions import ClientError
 from contextlib import asynccontextmanager
 
 from ..config import get_settings
-from ..models import User, Team, TeamMember, Check, Ping, Role, CheckStatus, PendingInvitation, AlertChannel, AlertChannelType, AlertDelivery, MaintenanceWindow, Report
+from ..models import User, Team, TeamMember, Check, Ping, Role, CheckStatus, PendingInvitation, AlertChannel, AlertChannelType, AlertDelivery, AuditEvent, MaintenanceWindow, Report
 from ..errors import PulsechecksError
 from ..utils import get_iso_timestamp, get_current_time_seconds
 from ..utils.retry import with_retry, RetryConfig
@@ -583,6 +583,57 @@ class DynamoDBClient(DatabaseInterface):
             await table.delete_item(
                 Key={"PK": f"TEAM#{team_id}", "SK": f"MAINTENANCE#{window_id}"}
             )
+
+    # Audit log operations
+
+    async def create_audit_event(self, event: AuditEvent) -> None:
+        """Persist an audit event."""
+        settings = get_settings()
+        ttl = get_current_time_seconds() + (settings.ping_retention_days * 24 * 60 * 60)
+        async with self._get_table() as table:
+            await table.put_item(Item={
+                "PK": f"TEAM#{event.team_id}",
+                "SK": f"AUDIT#{event.created_at}#{event.event_id}",
+                "eventId": event.event_id,
+                "teamId": event.team_id,
+                "actorId": event.actor_id,
+                "actorEmail": event.actor_email,
+                "action": event.action,
+                "targetType": event.target_type,
+                "targetId": event.target_id,
+                "targetName": event.target_name,
+                "detail": event.detail,
+                "createdAt": event.created_at,
+                "TTL": ttl,
+            })
+
+    async def list_audit_events(self, team_id: str, limit: int = 100) -> List[AuditEvent]:
+        """List audit events for a team, newest first."""
+        async with self._get_table() as table:
+            response = await table.query(
+                KeyConditionExpression="PK = :pk AND begins_with(SK, :sk_prefix)",
+                ExpressionAttributeValues={
+                    ":pk": f"TEAM#{team_id}",
+                    ":sk_prefix": "AUDIT#",
+                },
+                ScanIndexForward=False,
+                Limit=limit,
+            )
+            return [
+                AuditEvent(
+                    event_id=item["eventId"],
+                    team_id=item["teamId"],
+                    actor_id=item["actorId"],
+                    actor_email=item["actorEmail"],
+                    action=item["action"],
+                    target_type=item["targetType"],
+                    target_id=item["targetId"],
+                    target_name=item.get("targetName"),
+                    detail=item.get("detail"),
+                    created_at=item["createdAt"],
+                )
+                for item in response.get("Items", [])
+            ]
 
     # Alert delivery queue / history operations
 

--- a/backend/app/db/dynamodb.py
+++ b/backend/app/db/dynamodb.py
@@ -883,6 +883,24 @@ class DynamoDBClient(DatabaseInterface):
             tags=item.get("tags", []),
         )
 
+    async def query_due_http_checks(self, current_time_seconds: int, limit: int = 500) -> List[Check]:
+        """Query active HTTP checks due for polling (next_due_at missing or <= now).
+
+        Still scan-based (acceptable at current AWS scale) but the due
+        filter now runs server-side so only actionable items return.
+        """
+        async with self._get_table() as table:
+            response = await table.scan(
+                FilterExpression=(
+                    "attribute_exists(#type) AND #type = :http AND #status <> :paused "
+                    "AND (attribute_not_exists(nextDueAt) OR nextDueAt <= :now)"
+                ),
+                ExpressionAttributeNames={"#type": "type", "#status": "status"},
+                ExpressionAttributeValues={":http": "http", ":paused": "paused", ":now": current_time_seconds},
+            )
+            items = response.get("Items", [])
+            return [self._item_to_check(item) for item in items if "checkId" in item][:limit]
+
     async def list_all_http_checks(self) -> List[Check]:
         """List all active HTTP checks (type=http, status != paused)."""
         async with self._get_table() as table:

--- a/backend/app/db/dynamodb.py
+++ b/backend/app/db/dynamodb.py
@@ -238,6 +238,14 @@ class DynamoDBClient(DatabaseInterface):
                 item["url"] = check.url
             if check.expected_status_code != 200:
                 item["expectedStatusCode"] = check.expected_status_code
+            if check.slug:
+                item["slug"] = check.slug
+            if check.expected_string:
+                item["expectedString"] = check.expected_string
+            if check.failure_threshold and check.failure_threshold != 1:
+                item["failureThreshold"] = check.failure_threshold
+            if check.tags:
+                item["tags"] = check.tags
 
             # Add to token index
             item["GSI2PK"] = f"TOKEN#{check.token}"
@@ -859,10 +867,20 @@ class DynamoDBClient(DatabaseInterface):
             alert_channels=item.get("alertChannels", []),
             escalation_minutes=convert_to_int(item.get("escalationMinutes")) if item.get("escalationMinutes") else None,
             escalation_alert_channels=item.get("escalationAlertChannels", []),
+            escalation_triggered_at=item.get("escalationTriggeredAt"),
+            suppress_after_count=convert_to_int(item.get("suppressAfterCount")) if item.get("suppressAfterCount") else None,
+            suppress_duration_minutes=convert_to_int(item.get("suppressDurationMinutes")) if item.get("suppressDurationMinutes") else None,
+            consecutive_alert_count=convert_to_int(item.get("consecutiveAlertCount")) or 0,
+            suppressed_until=item.get("suppressedUntil"),
+            consecutive_failure_count=convert_to_int(item.get("consecutiveFailureCount")) or 0,
             type=item.get("type", "heartbeat"),
             schedule=item.get("schedule"),
             url=item.get("url"),
             expected_status_code=convert_to_int(item.get("expectedStatusCode")) or 200,
+            expected_string=item.get("expectedString"),
+            failure_threshold=convert_to_int(item.get("failureThreshold")) or 1,
+            slug=item.get("slug"),
+            tags=item.get("tags", []),
         )
 
     async def list_all_http_checks(self) -> List[Check]:

--- a/backend/app/db/firestore.py
+++ b/backend/app/db/firestore.py
@@ -343,7 +343,9 @@ class FirestoreClient(DatabaseInterface):
             'schedule': check.schedule,
             'url': check.url,
             'expectedStatusCode': check.expected_status_code,
+            'expectedString': check.expected_string,
             'failureThreshold': check.failure_threshold,
+            'tags': check.tags or [],
         }
 
         # Remove None values (but keep slug and other important fields)
@@ -1060,5 +1062,10 @@ class FirestoreClient(DatabaseInterface):
             schedule=data.get('schedule'),
             url=data.get('url'),
             expected_status_code=int(data.get('expectedStatusCode', 200)),
+            expected_string=data.get('expectedString'),
             failure_threshold=int(data.get('failureThreshold', 1)),
+            suppress_after_count=int(data['suppressAfterCount']) if data.get('suppressAfterCount') else None,
+            suppress_duration_minutes=int(data['suppressDurationMinutes']) if data.get('suppressDurationMinutes') else None,
+            consecutive_failure_count=int(data.get('consecutiveFailureCount', 0)),
+            tags=data.get('tags', []),
         )

--- a/backend/app/db/firestore.py
+++ b/backend/app/db/firestore.py
@@ -869,6 +869,36 @@ class FirestoreClient(DatabaseInterface):
 
         return checks
 
+    async def query_due_http_checks(self, current_time_seconds: int, limit: int = 500) -> List[Check]:
+        """Query active HTTP checks due for polling (next_due_at missing or <= now).
+
+        Uses the (type, nextDueAt) composite index instead of streaming
+        every HTTP check on every poll cycle.
+        """
+        checks_ref = self.db.collection('checks')
+        checks = []
+
+        due_query = (checks_ref
+                     .where('type', '==', 'http')
+                     .where('nextDueAt', '<=', current_time_seconds)
+                     .limit(limit))
+        async for doc in due_query.stream():
+            check = self._dict_to_check(doc.to_dict())
+            if check.status != CheckStatus.PAUSED.value:
+                checks.append(check)
+
+        # Never-polled checks have no nextDueAt yet
+        new_query = (checks_ref
+                     .where('type', '==', 'http')
+                     .where('nextDueAt', '==', None)
+                     .limit(limit))
+        async for doc in new_query.stream():
+            check = self._dict_to_check(doc.to_dict())
+            if check.status != CheckStatus.PAUSED.value:
+                checks.append(check)
+
+        return checks
+
     async def list_all_http_checks(self) -> List[Check]:
         """List all active HTTP checks (type=http, status != paused)."""
         checks_ref = self.db.collection('checks')

--- a/backend/app/db/firestore.py
+++ b/backend/app/db/firestore.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from ..config import get_settings
 from ..models import (
     User, Team, TeamMember, Check, Ping, Role, CheckStatus,
-    PendingInvitation, AlertChannel, AlertChannelType, AlertDelivery, MaintenanceWindow, Report
+    PendingInvitation, AlertChannel, AlertChannelType, AlertDelivery, AuditEvent, MaintenanceWindow, Report
 )
 from ..errors import PulsechecksError
 from ..utils import get_iso_timestamp, get_current_time_seconds
@@ -691,6 +691,51 @@ class FirestoreClient(DatabaseInterface):
         doc_ref = (self.db.collection('teams').document(team_id)
                    .collection('maintenance').document(window_id))
         await doc_ref.delete()
+
+    # Audit log operations
+
+    async def create_audit_event(self, event: AuditEvent) -> None:
+        """Persist an audit event."""
+        settings = get_settings()
+        ttl_seconds = get_current_time_seconds() + (settings.ping_retention_days * 24 * 60 * 60)
+        doc_ref = (self.db.collection('teams').document(event.team_id)
+                   .collection('audit').document(event.event_id))
+        await doc_ref.set({
+            'eventId': event.event_id,
+            'teamId': event.team_id,
+            'actorId': event.actor_id,
+            'actorEmail': event.actor_email,
+            'action': event.action,
+            'targetType': event.target_type,
+            'targetId': event.target_id,
+            'targetName': event.target_name,
+            'detail': event.detail,
+            'createdAt': event.created_at,
+            'ttl': datetime.fromtimestamp(ttl_seconds, tz=timezone.utc),
+        })
+
+    async def list_audit_events(self, team_id: str, limit: int = 100) -> List[AuditEvent]:
+        """List audit events for a team, newest first."""
+        query = (self.db.collection('teams').document(team_id)
+                 .collection('audit')
+                 .order_by('createdAt', direction='DESCENDING')
+                 .limit(limit))
+        events = []
+        async for doc in query.stream():
+            data = doc.to_dict()
+            events.append(AuditEvent(
+                event_id=data['eventId'],
+                team_id=data['teamId'],
+                actor_id=data['actorId'],
+                actor_email=data['actorEmail'],
+                action=data['action'],
+                target_type=data['targetType'],
+                target_id=data['targetId'],
+                target_name=data.get('targetName'),
+                detail=data.get('detail'),
+                created_at=data['createdAt'],
+            ))
+        return events
 
     # Alert delivery queue / history operations
 

--- a/backend/app/db/interface.py
+++ b/backend/app/db/interface.py
@@ -278,6 +278,11 @@ class DatabaseInterface(ABC):
         pass
 
     @abstractmethod
+    async def query_due_http_checks(self, current_time_seconds: int, limit: int = 500) -> List[Check]:
+        """Query active HTTP checks due for polling (next_due_at missing or <= now)."""
+        pass
+
+    @abstractmethod
     async def list_all_http_checks(self) -> List[Check]:
         """List all active HTTP checks (type=http, status != paused)."""
         pass

--- a/backend/app/db/interface.py
+++ b/backend/app/db/interface.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Dict, Any
 
 from ..models import (
     User, Team, TeamMember, Check, Ping, Role,
-    PendingInvitation, AlertChannel, AlertDelivery, MaintenanceWindow, Report
+    PendingInvitation, AlertChannel, AlertDelivery, AuditEvent, MaintenanceWindow, Report
 )
 
 
@@ -227,6 +227,18 @@ class DatabaseInterface(ABC):
     @abstractmethod
     async def delete_maintenance_window(self, team_id: str, window_id: str) -> None:
         """Delete a maintenance window."""
+        pass
+
+    # Audit log operations
+
+    @abstractmethod
+    async def create_audit_event(self, event: AuditEvent) -> None:
+        """Persist an audit event."""
+        pass
+
+    @abstractmethod
+    async def list_audit_events(self, team_id: str, limit: int = 100) -> List[AuditEvent]:
+        """List audit events for a team, newest first."""
         pass
 
     # Alert delivery queue / history operations

--- a/backend/app/handlers.py
+++ b/backend/app/handlers.py
@@ -89,6 +89,9 @@ async def _late_detector_impl(event: Dict[str, Any], context: Any) -> Dict[str, 
     # enqueued outside scheduler context (e.g. the ping recovery path).
     drain_stats = await process_due_deliveries(db)
 
+    # Dead-man's-switch: signal an external monitor that detection ran.
+    await _ping_heartbeat(settings)
+
     # Record enhanced metrics
     metrics.late_detection_run(len(due_checks), alerts_queued)
     log_business_event('enhanced_late_detection_run',
@@ -113,6 +116,17 @@ async def _late_detector_impl(event: Dict[str, Any], context: Any) -> Dict[str, 
             }
         ),
     }
+
+
+async def _ping_heartbeat(settings) -> None:
+    """Ping the configured dead-man's-switch URL (best effort, never raises)."""
+    if not settings.heartbeat_url:
+        return
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            await client.get(settings.heartbeat_url)
+    except Exception as e:
+        logger.warning(f"Dead-man's-switch heartbeat failed: {e}")
 
 
 def late_detector_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -28,7 +28,7 @@ from .responses import (
     OkResponse,
     AlertTopicResponse,
 )
-from .entities import User, Team, Check, Ping, TeamMember, PendingInvitation, AlertChannel, AlertDelivery, MaintenanceWindow, Report
+from .entities import User, Team, Check, Ping, TeamMember, PendingInvitation, AlertChannel, AlertDelivery, AuditEvent, MaintenanceWindow, Report
 
 __all__ = [
     # Enums
@@ -70,6 +70,7 @@ __all__ = [
     "Check",
     "Ping",
     "AlertDelivery",
+    "AuditEvent",
     "MaintenanceWindow",
     "Report",
     "TeamMember",

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -142,6 +142,21 @@ class AlertDelivery(BaseModel):
     delivered_at: Optional[str] = None
 
 
+class AuditEvent(BaseModel):
+    """A recorded administrative action (who did what, to what, when)."""
+
+    event_id: str
+    team_id: str
+    actor_id: str
+    actor_email: str
+    action: str  # e.g. check.created, channel.deleted, member.role_changed
+    target_type: str  # check | channel | member | team | token | maintenance
+    target_id: str
+    target_name: Optional[str] = None
+    detail: Optional[str] = None
+    created_at: str
+
+
 class MaintenanceWindow(BaseModel):
     """Scheduled maintenance window entity."""
 

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -95,6 +95,7 @@ class Check(BaseModel):
     # Escalation configuration
     escalation_minutes: Optional[int] = None  # Minutes before escalating
     escalation_alert_channels: list[str] = []  # Alert channels for escalated alerts
+    tags: list[str] = []  # Free-form labels for filtering/grouping
     escalation_mattermost_channels: list[str] = []  # Mattermost channels for escalated alerts (legacy)
     escalation_triggered_at: Optional[str] = None  # When escalation was last triggered
 

--- a/backend/app/models/requests.py
+++ b/backend/app/models/requests.py
@@ -43,6 +43,23 @@ class CreateCheckRequest(BaseModel):
     expected_status_code: int = Field(default=200, ge=100, le=599, alias="expectedStatusCode", description="Expected HTTP status code")
     expected_string: Optional[str] = Field(None, max_length=1000, alias="expectedString", description="Expected string in response body")
     failure_threshold: int = Field(default=1, ge=1, le=100, alias="failureThreshold", description="Alert after N consecutive failures")
+    tags: list[str] = Field(default_factory=list, max_length=10, description="Up to 10 labels for filtering/grouping")
+
+    @field_validator("tags")
+    @classmethod
+    def validate_tags(cls, v: list[str]) -> list[str]:
+        cleaned = []
+        for tag in v:
+            tag = tag.strip().lower()
+            if not tag:
+                continue
+            if len(tag) > 30:
+                raise ValueError("tags must be at most 30 characters")
+            if not all(c.isalnum() or c in "-_." for c in tag):
+                raise ValueError("tags may only contain letters, digits, '-', '_' and '.'")
+            if tag not in cleaned:
+                cleaned.append(tag)
+        return cleaned
 
     @field_validator("name")
     @classmethod
@@ -107,10 +124,30 @@ class UpdateCheckRequest(BaseModel):
 
     # Escalation configuration
     escalation_minutes: Optional[int] = Field(None, ge=1, le=1440, alias="escalationMinutes", description="Minutes before escalating")
+    escalation_alert_channels: Optional[list[str]] = Field(None, alias="escalationAlertChannels", description="Alert channels for escalated alerts")
 
     # Suppression configuration
     suppress_after_count: Optional[int] = Field(None, ge=1, le=100, alias="suppressAfterCount", description="Suppress after N consecutive alerts")
     suppress_duration_minutes: Optional[int] = Field(None, ge=1, le=10080, alias="suppressDurationMinutes", description="Suppress for N minutes")
+    tags: Optional[list[str]] = Field(None, max_length=10, description="Up to 10 labels for filtering/grouping")
+
+    @field_validator("tags")
+    @classmethod
+    def validate_update_tags(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+        if v is None:
+            return None
+        cleaned = []
+        for tag in v:
+            tag = tag.strip().lower()
+            if not tag:
+                continue
+            if len(tag) > 30:
+                raise ValueError("tags must be at most 30 characters")
+            if not all(c.isalnum() or c in "-_." for c in tag):
+                raise ValueError("tags may only contain letters, digits, '-', '_' and '.'")
+            if tag not in cleaned:
+                cleaned.append(tag)
+        return cleaned
 
     @field_validator("name")
     @classmethod

--- a/backend/app/models/requests.py
+++ b/backend/app/models/requests.py
@@ -123,12 +123,12 @@ class UpdateCheckRequest(BaseModel):
     failure_threshold: Optional[int] = Field(None, ge=1, le=100, alias="failureThreshold", description="Alert after N consecutive failures")
 
     # Escalation configuration
-    escalation_minutes: Optional[int] = Field(None, ge=1, le=1440, alias="escalationMinutes", description="Minutes before escalating")
+    escalation_minutes: Optional[int] = Field(None, ge=0, le=1440, alias="escalationMinutes", description="Minutes before escalating (0 disables escalation)")
     escalation_alert_channels: Optional[list[str]] = Field(None, alias="escalationAlertChannels", description="Alert channels for escalated alerts")
 
     # Suppression configuration
-    suppress_after_count: Optional[int] = Field(None, ge=1, le=100, alias="suppressAfterCount", description="Suppress after N consecutive alerts")
-    suppress_duration_minutes: Optional[int] = Field(None, ge=1, le=10080, alias="suppressDurationMinutes", description="Suppress for N minutes")
+    suppress_after_count: Optional[int] = Field(None, ge=0, le=100, alias="suppressAfterCount", description="Suppress after N consecutive alerts (0 disables)")
+    suppress_duration_minutes: Optional[int] = Field(None, ge=0, le=10080, alias="suppressDurationMinutes", description="Suppress for N minutes (0 disables)")
     tags: Optional[list[str]] = Field(None, max_length=10, description="Up to 10 labels for filtering/grouping")
 
     @field_validator("tags")

--- a/backend/app/models/responses.py
+++ b/backend/app/models/responses.py
@@ -53,6 +53,7 @@ class CheckResponse(BaseModel):
     expected_status_code: int = Field(default=200, alias="expectedStatusCode")
     expected_string: Optional[str] = Field(None, alias="expectedString")
     failure_threshold: int = Field(default=1, alias="failureThreshold")
+    tags: List[str] = Field(default_factory=list)
 
 
 class CheckDetailResponse(CheckResponse):
@@ -65,6 +66,7 @@ class CheckDetailResponse(CheckResponse):
 
     # Escalation configuration
     escalation_minutes: Optional[int] = Field(None, alias="escalationMinutes")
+    escalation_alert_channels: List[str] = Field(default_factory=list, alias="escalationAlertChannels")
     escalation_triggered_at: Optional[str] = Field(None, alias="escalationTriggeredAt")
 
     # Suppression configuration

--- a/backend/app/routers/api_tokens.py
+++ b/backend/app/routers/api_tokens.py
@@ -11,6 +11,7 @@ from ..dependencies import AuthUser, Database, check_team_access
 from ..models import Permission
 from ..utils import get_iso_timestamp
 from ..utils.token_security import timing_safe_compare, validate_token_entropy, validate_token_format
+from ..audit import record_audit
 
 router = APIRouter(prefix="/teams/{team_id}/api-tokens", tags=["api-tokens"])
 
@@ -83,6 +84,7 @@ async def create_api_token(
     # Store in Firestore
     col = db.db.collection(COLLECTION)
     await col.document(token_id).set(doc)
+    await record_audit(db, team_id, current_user, "token.created", "token", token_id, name)
 
     return {**doc, "token": token}
 
@@ -131,4 +133,5 @@ async def revoke_api_token(
         raise HTTPException(status_code=404, detail="Token not found")
 
     await doc_ref.delete()
+    await record_audit(db, team_id, current_user, "token.revoked", "token", token_id, doc.to_dict().get("name"))
     return {"deleted": True, "token_id": token_id}

--- a/backend/app/routers/channels.py
+++ b/backend/app/routers/channels.py
@@ -11,6 +11,7 @@ from ..utils import get_iso_timestamp
 from ..config import get_settings
 from ..ssrf_utils import validate_webhook_url_strict, SSRFValidationError
 from ..posthog_client import get_posthog_client, new_context, identify_context
+from ..audit import record_audit
 
 router = APIRouter(prefix="/teams/{team_id}/channels", tags=["alert-channels"])
 
@@ -98,6 +99,7 @@ async def create_alert_channel(
     )
     
     await db.create_alert_channel(channel)
+    await record_audit(db, team_id, current_user, "channel.created", "channel", channel_id, display_name, detail=f"type: {alert_type.value}")
 
     posthog = get_posthog_client()
     with new_context(client=posthog):
@@ -183,7 +185,8 @@ async def update_alert_channel(
         channel.shared = request["shared"]
     
     await db.update_alert_channel(channel)
-    
+    await record_audit(db, team_id, current_user, "channel.updated", "channel", channel_id, channel.display_name)
+
     return {
         "channelId": channel.channel_id,
         "teamId": channel.team_id,
@@ -225,6 +228,7 @@ async def delete_alert_channel(
             print(f"Warning: Failed to delete SNS topic {topic_arn}: {e}")
     
     await db.delete_alert_channel(team_id, channel_id)
+    await record_audit(db, team_id, current_user, "channel.deleted", "channel", channel_id, channel.display_name, detail=f"type: {channel.type.value}")
 
     posthog = get_posthog_client()
     with new_context(client=posthog):

--- a/backend/app/routers/checks.py
+++ b/backend/app/routers/checks.py
@@ -566,15 +566,16 @@ async def update_check(
     if request.alert_channels is not None:
         updates["alertChannels"] = request.alert_channels
     if request.escalation_minutes is not None:
-        updates["escalationMinutes"] = request.escalation_minutes
+        # 0 disables escalation
+        updates["escalationMinutes"] = request.escalation_minutes or None
     if request.escalation_alert_channels is not None:
         updates["escalationAlertChannels"] = request.escalation_alert_channels
     if request.tags is not None:
         updates["tags"] = request.tags
     if request.suppress_after_count is not None:
-        updates["suppressAfterCount"] = request.suppress_after_count
+        updates["suppressAfterCount"] = request.suppress_after_count or None
     if request.suppress_duration_minutes is not None:
-        updates["suppressDurationMinutes"] = request.suppress_duration_minutes
+        updates["suppressDurationMinutes"] = request.suppress_duration_minutes or None
     if request.url is not None:
         updates["url"] = request.url
     if request.expected_status_code is not None:

--- a/backend/app/routers/checks.py
+++ b/backend/app/routers/checks.py
@@ -311,6 +311,7 @@ def _check_detail_response(check) -> CheckDetailResponse:
         createdAt=check.created_at,
         alertChannels=check.alert_channels,
         escalationMinutes=check.escalation_minutes,
+        escalationAlertChannels=getattr(check, 'escalation_alert_channels', []) or [],
         escalationTriggeredAt=getattr(check, 'escalation_triggered_at', None),
         suppressAfterCount=getattr(check, 'suppress_after_count', None),
         suppressDurationMinutes=getattr(check, 'suppress_duration_minutes', None),
@@ -321,6 +322,7 @@ def _check_detail_response(check) -> CheckDetailResponse:
         expectedStatusCode=getattr(check, 'expected_status_code', 200),
         expectedString=getattr(check, 'expected_string', None),
         failureThreshold=getattr(check, 'failure_threshold', 1),
+        tags=getattr(check, 'tags', []) or [],
     )
 
 
@@ -450,6 +452,7 @@ async def create_check(
         expected_status_code=request.expected_status_code,
         expected_string=request.expected_string,
         failure_threshold=request.failure_threshold,
+        tags=request.tags,
     )
     # Pre-compute next_due_at for cron checks so the late detector can find them immediately
     if request.type == "cron":
@@ -510,6 +513,7 @@ async def list_team_checks(
             expectedStatusCode=check.expected_status_code,
             expectedString=getattr(check, 'expected_string', None),
             failureThreshold=getattr(check, 'failure_threshold', 1),
+            tags=getattr(check, 'tags', []) or [],
         )
         for check in checks
     ]
@@ -563,6 +567,10 @@ async def update_check(
         updates["alertChannels"] = request.alert_channels
     if request.escalation_minutes is not None:
         updates["escalationMinutes"] = request.escalation_minutes
+    if request.escalation_alert_channels is not None:
+        updates["escalationAlertChannels"] = request.escalation_alert_channels
+    if request.tags is not None:
+        updates["tags"] = request.tags
     if request.suppress_after_count is not None:
         updates["suppressAfterCount"] = request.suppress_after_count
     if request.suppress_duration_minutes is not None:

--- a/backend/app/routers/checks.py
+++ b/backend/app/routers/checks.py
@@ -11,6 +11,7 @@ from ..metrics import get_metrics_client
 from ..utils import generate_token, get_iso_timestamp, get_current_time_seconds, generate_slug
 from ..utils.common import parse_iso_timestamp
 from ..posthog_client import get_posthog_client, new_context, identify_context
+from ..audit import record_audit
 
 logger = get_logger(__name__)
 from ..models import (
@@ -460,6 +461,7 @@ async def create_check(
         check.alert_after_at = str(int(check.next_due_at) + request.grace_seconds)
 
     await db.create_check(check)
+    await record_audit(db, team_id, current_user, "check.created", "check", check_id, request.name)
 
     # Record metrics and log business event
     metrics = get_metrics_client()
@@ -604,6 +606,10 @@ async def update_check(
         updates["nextDueAt"] = calculate_next_due(last_ping_seconds, period)
 
     updated_check = await db.update_check(team_id, check_id, updates)
+    await record_audit(
+        db, team_id, current_user, "check.updated", "check", check_id, check.name,
+        detail="changed: " + ", ".join(sorted(updates.keys())),
+    )
     return _check_detail_response(updated_check)
 
 
@@ -625,6 +631,7 @@ async def pause_check(
 
     # Update status to paused
     await db.update_check(team_id, check_id, {"status": CheckStatus.PAUSED.value})
+    await record_audit(db, team_id, current_user, "check.paused", "check", check_id, check.name)
 
     posthog = get_posthog_client()
     with new_context(client=posthog):
@@ -656,6 +663,7 @@ async def resume_check(
 
     # Update status to up
     await db.update_check(team_id, check_id, {"status": CheckStatus.UP.value})
+    await record_audit(db, team_id, current_user, "check.resumed", "check", check_id, check.name)
 
     posthog = get_posthog_client()
     with new_context(client=posthog):
@@ -691,6 +699,7 @@ async def rotate_check_token(
     # Update check with new token
     updates = {"token": new_token}
     updated_check = await db.update_check(team_id, check_id, updates)
+    await record_audit(db, team_id, current_user, "check.token_rotated", "check", check_id, check.name)
 
     return _check_detail_response(updated_check)
 
@@ -780,6 +789,7 @@ async def delete_check(
 
     # Delete check (this should cascade delete pings)
     await db.delete_check(team_id, check_id)
+    await record_audit(db, team_id, current_user, "check.deleted", "check", check_id, check.name)
 
     # Record metrics and log business event
     metrics = get_metrics_client()

--- a/backend/app/routers/teams.py
+++ b/backend/app/routers/teams.py
@@ -16,6 +16,8 @@ from ..utils import generate_id, get_iso_timestamp, generate_slug
 from ..logging_config import log_business_event
 from ..posthog_client import get_posthog_client, new_context, identify_context
 
+from ..audit import record_audit
+
 router = APIRouter(prefix="/teams", tags=["teams"])
 
 
@@ -225,6 +227,7 @@ async def add_team_member(
             joined_at=get_iso_timestamp(),
         )
         await db.add_team_member(new_member)
+        await record_audit(db, team_id, current_user, "member.added", "member", user.user_id, email, detail=f"role: {role.value}")
 
         posthog = get_posthog_client()
         with new_context(client=posthog):
@@ -265,6 +268,7 @@ async def add_team_member(
             invited_at=get_iso_timestamp(),
         )
         await db.create_pending_invitation(invitation)
+        await record_audit(db, team_id, current_user, "member.invited", "member", email, email, detail=f"role: {role.value}")
 
         posthog = get_posthog_client()
         with new_context(client=posthog):
@@ -307,7 +311,8 @@ async def remove_team_member(
     
     # Remove member
     await db.remove_team_member(team_id, user_id)
-    
+    await record_audit(db, team_id, current_user, "member.removed", "member", user_id)
+
     return {"message": "Member removed successfully"}
 
 
@@ -343,7 +348,8 @@ async def update_team_member_role(
     
     # Update member role
     await db.update_team_member_role(team_id, user_id, new_role)
-    
+    await record_audit(db, team_id, current_user, "member.role_changed", "member", user_id, detail=f"new role: {new_role.value}")
+
     return {"message": "Member role updated successfully"}
 
 
@@ -529,7 +535,9 @@ async def delete_team(
             detail="Team name confirmation does not match. Please type the exact team name."
         )
     
-    # Perform cascade delete
+    # Perform cascade delete. Audit is recorded first — the team's audit
+    # trail is deleted with the team, but the attempt is logged.
+    await record_audit(db, team_id, current_user, "team.deleted", "team", team_id, team.name)
     await db.delete_team(team_id)
 
     posthog = get_posthog_client()
@@ -542,3 +550,33 @@ async def delete_team(
         )
 
     return {"message": f"Team '{team.name}' and all associated data deleted successfully"}
+
+
+@router.get("/{team_id}/audit")
+async def list_team_audit_events(
+    team_id: str,
+    current_user: AuthUser,
+    db: Database,
+    limit: int = 100,
+):
+    """List the team's audit log (admin only), newest first."""
+    member = await db.get_team_member(team_id, current_user.user_id)
+    if not member or member.role != Role.ADMIN:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    limit = max(1, min(limit, 200))
+    events = await db.list_audit_events(team_id, limit=limit)
+    return [
+        {
+            "eventId": e.event_id,
+            "actorId": e.actor_id,
+            "actorEmail": e.actor_email,
+            "action": e.action,
+            "targetType": e.target_type,
+            "targetId": e.target_id,
+            "targetName": e.target_name,
+            "detail": e.detail,
+            "createdAt": e.created_at,
+        }
+        for e in events
+    ]

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -11,40 +11,34 @@ from .utils import get_iso_timestamp, get_current_time_seconds, calculate_next_d
 logger = get_logger(__name__)
 
 HTTP_TIMEOUT = 10  # seconds
+POLL_CONCURRENCY = 10  # max simultaneous outbound HTTP probes
 
 
 async def poll_http_checks():
-    """Poll all active HTTP checks that are due."""
+    """Poll active HTTP checks that are due.
+
+    Due-filtering happens in the database (indexed on Firestore) so the
+    poller only sees actionable checks, and probes run under a bounded
+    concurrency cap so a large fleet of slow endpoints can't exhaust
+    connections or blow past the scheduler window.
+    """
     db = create_db_client()
-    all_checks = await db.list_all_http_checks()
-
-    if not all_checks:
-        return
-
-    # Only poll checks that are actually due (next_due_at <= now)
     now = get_current_time_seconds()
-    due_checks = []
-    for check in all_checks:
-        if check.next_due_at is None:
-            # Never been polled — poll now
-            due_checks.append(check)
-        else:
-            try:
-                from datetime import datetime, timezone
-                due_dt = datetime.fromisoformat(check.next_due_at.replace("Z", "+00:00"))
-                if due_dt.timestamp() <= now:
-                    due_checks.append(check)
-            except Exception:
-                due_checks.append(check)
+    due_checks = await db.query_due_http_checks(now)
 
     if not due_checks:
         return
 
-    logger.info(f"HTTP poller: {len(due_checks)} checks due out of {len(all_checks)} total")
+    logger.info(f"HTTP poller: {len(due_checks)} checks due")
+
+    semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=False) as client:
-        tasks = [_poll_single_check(client, db, check) for check in due_checks]
-        await asyncio.gather(*tasks, return_exceptions=True)
+        async def _bounded_poll(check):
+            async with semaphore:
+                await _poll_single_check(client, db, check)
+
+        await asyncio.gather(*(_bounded_poll(check) for check in due_checks), return_exceptions=True)
 
 
 async def _poll_single_check(client, db, check):

--- a/backend/firestore.indexes.json
+++ b/backend/firestore.indexes.json
@@ -1,6 +1,14 @@
 {
   "indexes": [
     {
+      "collectionGroup": "checks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "nextDueAt", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "alertDeliveries",
       "queryScope": "COLLECTION",
       "fields": [

--- a/backend/tests/test_alert_dispatch.py
+++ b/backend/tests/test_alert_dispatch.py
@@ -174,3 +174,38 @@ class TestQueueDrain:
         db.query_due_alert_deliveries.return_value = []
         stats = await process_due_deliveries(db)
         assert stats["processed"] == 0
+
+
+class TestDeadMansSwitch:
+    @pytest.mark.asyncio
+    async def test_heartbeat_pinged_when_configured(self):
+        from app.handlers import _ping_heartbeat
+
+        settings = MagicMock()
+        settings.heartbeat_url = "https://hc-ping.example.com/uuid"
+        mock_client = AsyncMock()
+
+        with patch("app.handlers.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value.__aenter__.return_value = mock_client
+            await _ping_heartbeat(settings)
+
+        mock_client.get.assert_awaited_once_with("https://hc-ping.example.com/uuid")
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_skipped_when_unset(self):
+        from app.handlers import _ping_heartbeat
+
+        settings = MagicMock()
+        settings.heartbeat_url = ""
+        with patch("app.handlers.httpx.AsyncClient") as mock_cls:
+            await _ping_heartbeat(settings)
+        mock_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_failure_never_raises(self):
+        from app.handlers import _ping_heartbeat
+
+        settings = MagicMock()
+        settings.heartbeat_url = "https://hc-ping.example.com/uuid"
+        with patch("app.handlers.httpx.AsyncClient", side_effect=RuntimeError("network down")):
+            await _ping_heartbeat(settings)  # must not raise

--- a/backend/tests/test_audit_log.py
+++ b/backend/tests/test_audit_log.py
@@ -1,0 +1,84 @@
+"""Tests for the team audit log."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.audit import record_audit
+from app.models import AuditEvent, TeamMember, Role, User
+
+client = TestClient(app)
+
+
+class TestRecordAudit:
+    @pytest.mark.asyncio
+    async def test_records_event_with_actor(self):
+        db = AsyncMock()
+        actor = MagicMock(user_id="user-1", email="admin@example.com")
+
+        await record_audit(db, "team-1", actor, "check.deleted", "check", "check-9", "Nightly Backup")
+
+        db.create_audit_event.assert_called_once()
+        event = db.create_audit_event.call_args[0][0]
+        assert event.team_id == "team-1"
+        assert event.actor_email == "admin@example.com"
+        assert event.action == "check.deleted"
+        assert event.target_name == "Nightly Backup"
+
+    @pytest.mark.asyncio
+    async def test_audit_failure_never_raises(self):
+        db = AsyncMock()
+        db.create_audit_event.side_effect = RuntimeError("db down")
+        actor = MagicMock(user_id="user-1", email="admin@example.com")
+
+        # Must not raise — audit failures can't break admin actions
+        await record_audit(db, "team-1", actor, "check.deleted", "check", "check-9")
+
+
+@patch('app.dependencies.create_db_client')
+@patch("app.dependencies.verify_jwt_token")
+def test_audit_endpoint_admin_only(mock_verify, mock_create_db, mock_jwt_token="tok"):
+    mock_verify.return_value = {
+        "sub": "user-1", "email": "member@example.com",
+        "email_verified": True, "name": "Member",
+    }
+    mock_db = MagicMock()
+    mock_create_db.return_value = mock_db
+    mock_db.get_team_member = AsyncMock(return_value=TeamMember(
+        team_id="team-1", user_id="user-1", role=Role.MEMBER,
+        joined_at="2025-01-01T00:00:00Z",
+    ))
+
+    response = client.get("/teams/team-1/audit", headers={"Authorization": "Bearer tok"})
+    assert response.status_code == 403
+
+
+@patch('app.dependencies.create_db_client')
+@patch("app.dependencies.verify_jwt_token")
+def test_audit_endpoint_returns_events(mock_verify, mock_create_db):
+    mock_verify.return_value = {
+        "sub": "user-1", "email": "admin@example.com",
+        "email_verified": True, "name": "Admin",
+    }
+    mock_db = MagicMock()
+    mock_create_db.return_value = mock_db
+    mock_db.get_team_member = AsyncMock(return_value=TeamMember(
+        team_id="team-1", user_id="user-1", role=Role.ADMIN,
+        joined_at="2025-01-01T00:00:00Z",
+    ))
+    mock_db.list_audit_events = AsyncMock(return_value=[
+        AuditEvent(
+            event_id="evt-1", team_id="team-1", actor_id="user-1",
+            actor_email="admin@example.com", action="check.deleted",
+            target_type="check", target_id="check-9", target_name="Nightly Backup",
+            created_at="2026-01-01T00:00:00Z",
+        ),
+    ])
+
+    response = client.get("/teams/team-1/audit", headers={"Authorization": "Bearer tok"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["action"] == "check.deleted"
+    assert data[0]["actorEmail"] == "admin@example.com"
+    assert data[0]["targetName"] == "Nightly Backup"

--- a/backend/tests/test_http_checks.py
+++ b/backend/tests/test_http_checks.py
@@ -155,11 +155,10 @@ class TestPollSingleCheck:
 class TestPollHttpChecks:
     @pytest.mark.asyncio
     async def test_skips_checks_not_yet_due(self):
-        future_due = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
-        check = make_check(next_due_at=future_due)
-
+        """Due-filtering now happens in the database query — an empty
+        result means nothing is polled."""
         mock_db = AsyncMock()
-        mock_db.list_all_http_checks.return_value = [check]
+        mock_db.query_due_http_checks.return_value = []
 
         with patch("app.scheduler.create_db_client", return_value=mock_db), \
              patch("app.scheduler._poll_single_check", new_callable=AsyncMock) as mock_poll:
@@ -172,7 +171,7 @@ class TestPollHttpChecks:
         check = make_check(next_due_at=past_due)
 
         mock_db = AsyncMock()
-        mock_db.list_all_http_checks.return_value = [check]
+        mock_db.query_due_http_checks.return_value = [check]
 
         with patch("app.scheduler.create_db_client", return_value=mock_db), \
              patch("app.scheduler._poll_single_check", new_callable=AsyncMock) as mock_poll:
@@ -185,7 +184,7 @@ class TestPollHttpChecks:
         check = make_check(next_due_at=None)
 
         mock_db = AsyncMock()
-        mock_db.list_all_http_checks.return_value = [check]
+        mock_db.query_due_http_checks.return_value = [check]
 
         with patch("app.scheduler.create_db_client", return_value=mock_db), \
              patch("app.scheduler._poll_single_check", new_callable=AsyncMock) as mock_poll:

--- a/docs/gcp-deployment.md
+++ b/docs/gcp-deployment.md
@@ -171,6 +171,7 @@ The Cloud Run service will be configured with these environment variables (set a
 - `ALLOWED_EMAIL_DOMAINS=example.com`
 - `DEBUG=false`
 - `PING_RETENTION_DAYS=90` (optional — how long ping history is kept; default 90)
+- `HEARTBEAT_URL=` (optional — external dead-man's-switch pinged after each late-detection run; point it at an independent monitor such as a healthchecks.io check)
 
 ### Frontend Environment Variables
 

--- a/docs/plans/multi-region-ingestion.md
+++ b/docs/plans/multi-region-ingestion.md
@@ -1,0 +1,82 @@
+# Multi-Region Ping Ingestion Plan (GCP)
+
+**Status:** Plan — apply when check volume or an availability commitment demands it.
+**Goal:** 99.99% availability for the *ping ingestion path* specifically.
+**Prerequisite honesty:** this is a **migration**, not a Terraform flag. The
+current Firestore database was created in a single region, and Firestore's
+location is immutable after creation. Everything else in this plan is
+additive, but the database step requires an export/import migration window.
+
+## Why ingestion-first
+
+For a monitoring product, the failure that destroys trust is a *lost ping*
+(false "late" alerts) or a *missed alert*. Dashboard/API downtime is
+annoying; ingestion downtime is product failure. So the plan raises the
+ingestion path to active-active multi-region and deliberately leaves the
+management API single-region until later.
+
+Current ingestion ceiling (single region): Cloud Run SLA 99.95% × regional
+Firestore 99.99% ≈ **99.94%**. Target stack: global LB 99.99% × two
+Cloud Run regions (independent failures) × multi-region Firestore 99.999%
+≈ **99.98–99.99%**.
+
+## Step 1 — Firestore to multi-region (the migration)
+
+1. Create a new Firestore database in `nam5` (US multi-region) or `eur3`
+   (Europe multi-region) — pick based on where checks ping from.
+2. Announce a short maintenance window (pings buffered by senders' retries;
+   most cron jobs simply ping again next period).
+3. `gcloud firestore export` from the regional DB → `gcloud firestore import`
+   into the multi-region DB. At current data sizes this is minutes.
+4. Flip `FIRESTORE_DATABASE` on Cloud Run to the new database name and
+   redeploy. The backend already treats the database name as config.
+5. Re-apply the Firestore indexes/TTL Terraform against the new database
+   (all index definitions are already in `infra/gcp/firestore.tf` and
+   `backend/firestore.indexes.json`).
+
+Multi-region Firestore alone lifts the data layer to 99.999% and removes
+the biggest single-region dependency, even before step 2.
+
+## Step 2 — Second Cloud Run region behind the global LB
+
+The repo already provisions a global external HTTPS load balancer when
+`edge_throttling_enabled = true` (Cloud Armor path). Extend it:
+
+1. Deploy the same container as a second `google_cloud_run_service` in a
+   second region (e.g. `us-east1` alongside `us-central1`), same env vars —
+   Firestore multi-region serves both with no code changes.
+2. Create a serverless NEG per region and put **both** NEGs in the LB's
+   backend service. Outlier detection ejects an unhealthy region
+   automatically; requests route to the nearest healthy region.
+3. Keep Cloud Scheduler jobs (late detection, HTTP poll) targeting **one**
+   region only — the detector is a singleton by design; the delivery queue
+   makes its work durable. If the scheduler region is down, the dead-man's-
+   switch (`HEARTBEAT_URL`) fires and detection resumes on the next tick
+   after recovery. (Optional hardening: a second scheduler job, paused,
+   in the other region as a manual failover.)
+
+Terraform sketch (variables to add): `secondary_region`,
+`enable_multi_region` gating the second service + NEG. Estimated cost:
+one extra idle-scale-to-zero Cloud Run service ≈ $0; the global LB is
+already paid for by the edge-throttling setup (~$18/month).
+
+## Step 3 — Verify
+
+- Synthetic pings from two geographies through the LB, per-region
+  Cloud Run logs confirming both serve traffic.
+- Chaos drill: disable the primary region's Cloud Run service; confirm
+  pings keep landing (LB fails over) and late detection resumes within
+  one scheduler tick after re-enable, with the delivery queue draining
+  any backlog.
+- The existing `no pings in 30 min` style alarms plus
+  `AlertDeliveryExhausted` remain the canaries.
+
+## Explicitly out of scope (and why)
+
+- **Multi-region management API/frontend** — Firebase Hosting is already
+  a global CDN; the API's 99.9% is acceptable for a dashboard.
+- **Multi-cloud active-active** — operational cost far exceeds the
+  availability gain; the AWS stack remains a cold-standby option.
+- **Six nines** — not achievable on any serverless dependency chain and
+  not required: with retried pings and a durable alert queue, brief
+  ingestion blips do not lose data or alerts.

--- a/frontend/src/__tests__/ChecksPage.test.jsx
+++ b/frontend/src/__tests__/ChecksPage.test.jsx
@@ -192,7 +192,8 @@ describe('ChecksPage', () => {
         schedule: '',
         url: '',
         expectedStatusCode: 200,
-        failureThreshold: 1
+        failureThreshold: 1,
+        tags: []
       });
     });
   });
@@ -557,7 +558,8 @@ describe('ChecksPage', () => {
       expect(api.updateCheck).toHaveBeenCalledWith('team-123', 'check-1', {
         name: 'Updated Check Name',
         periodSeconds: 7200, // 2 hours * 3600 seconds
-        graceSeconds: 300 // 5 minutes unchanged
+        graceSeconds: 300, // 5 minutes unchanged
+        tags: []
       });
     });
   });

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -202,6 +202,11 @@ class ApiClient {
     return this.request(`/teams/${team_id}/checks/${check_id}/stats?${params}`)
   }
 
+  async getTeamAuditLog(team_id, limit = 100) {
+    const params = new URLSearchParams({ limit })
+    return this.request(`/teams/${team_id}/audit?${params}`)
+  }
+
   async getCheckAlertHistory(team_id, check_id, limit = 50) {
     const params = new URLSearchParams({ limit })
     return this.request(`/teams/${team_id}/checks/${check_id}/alert-history?${params}`)

--- a/frontend/src/pages/CheckDetailPage.jsx
+++ b/frontend/src/pages/CheckDetailPage.jsx
@@ -75,6 +75,8 @@ export default function CheckDetailPage({ user, onLogout }) {
   const [showTokenRotated, setShowTokenRotated] = useState(false)
   const [confirmState, setConfirmState] = useState(null)
   const [alertHistory, setAlertHistory] = useState([])
+  const [escalationForm, setEscalationForm] = useState({ escalationMinutes: 0, escalationAlertChannels: [], suppressAfterCount: 0, suppressDurationMinutes: 0 })
+  const [savingEscalation, setSavingEscalation] = useState(false)
   const [availableTopics, setAvailableTopics] = useState([])
   const [availableChannels, setAvailableChannels] = useState([])
   const [teamSlug, setTeamSlug] = useState(null)
@@ -139,6 +141,12 @@ export default function CheckDetailPage({ user, onLogout }) {
         checkData.pingUrl = `${getPingBaseUrl()}/ping/${checkData.token}`
       }
       setCheck(checkData)
+      setEscalationForm({
+        escalationMinutes: checkData.escalationMinutes || 0,
+        escalationAlertChannels: checkData.escalationAlertChannels || [],
+        suppressAfterCount: checkData.suppressAfterCount || 0,
+        suppressDurationMinutes: checkData.suppressDurationMinutes || 0,
+      })
       // Backend returns array directly, not wrapped in {pings: [...]}
       setPings(Array.isArray(pingsData) ? pingsData : pingsData.pings || [])
     } catch {
@@ -315,6 +323,24 @@ export default function CheckDetailPage({ user, onLogout }) {
       toast.error('Failed to update alert channels: ' + error.message)
       // Revert on error
       loadCheckData()
+    }
+  }
+
+  async function handleSaveEscalation() {
+    setSavingEscalation(true)
+    try {
+      const updated = await api.updateCheck(teamId, checkId, {
+        escalationMinutes: escalationForm.escalationMinutes,
+        escalationAlertChannels: escalationForm.escalationAlertChannels,
+        suppressAfterCount: escalationForm.suppressAfterCount,
+        suppressDurationMinutes: escalationForm.suppressDurationMinutes,
+      })
+      setCheck(updated)
+      toast.success('Escalation settings saved')
+    } catch (error) {
+      toast.error('Failed to save escalation settings: ' + error.message)
+    } finally {
+      setSavingEscalation(false)
     }
   }
 
@@ -1205,7 +1231,100 @@ export default function CheckDetailPage({ user, onLogout }) {
                   )}
                 </div>
 
-                {/* You may want to add more alert configuration sections here, e.g., Alert Topics, etc. */}
+                {/* Escalation & Suppression */}
+                <div className="border-t border-gray-200 pt-4">
+                  <div className="text-sm font-medium text-gray-700 mb-1">Escalation</div>
+                  <p className="text-sm text-gray-500 mb-3">
+                    If the check stays late, notify additional channels after a delay. Set to 0 to disable.
+                  </p>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                      <label htmlFor="escalationMinutes" className="block text-sm text-gray-700">Escalate after (minutes)</label>
+                      <input
+                        type="number"
+                        id="escalationMinutes"
+                        min="0"
+                        max="1440"
+                        value={escalationForm.escalationMinutes}
+                        onChange={(e) => setEscalationForm({ ...escalationForm, escalationMinutes: parseInt(e.target.value) || 0 })}
+                        className="mt-1 block w-32 border border-gray-300 rounded-md shadow-sm py-2 px-3 text-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <span className="block text-sm text-gray-700 mb-1">Escalation channels</span>
+                      {availableChannels.length === 0 ? (
+                        <p className="text-sm text-gray-500">No channels available</p>
+                      ) : (
+                        <div className="space-y-1 max-h-32 overflow-y-auto">
+                          {availableChannels.map((channel) => (
+                            <label key={channel.channelId} className="flex items-center">
+                              <input
+                                type="checkbox"
+                                checked={escalationForm.escalationAlertChannels.includes(channel.channelId)}
+                                onChange={(e) => {
+                                  const current = escalationForm.escalationAlertChannels
+                                  setEscalationForm({
+                                    ...escalationForm,
+                                    escalationAlertChannels: e.target.checked
+                                      ? [...current, channel.channelId]
+                                      : current.filter(id => id !== channel.channelId),
+                                  })
+                                }}
+                                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                              />
+                              <span className="ml-2 text-sm text-gray-900">{channel.displayName} ({channel.type.toUpperCase()})</span>
+                            </label>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="text-sm font-medium text-gray-700 mt-5 mb-1">Alert suppression</div>
+                  <p className="text-sm text-gray-500 mb-3">
+                    Mute repeat alerts after N consecutive notifications. Set to 0 to disable.
+                  </p>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                      <label htmlFor="suppressAfterCount" className="block text-sm text-gray-700">Suppress after (alerts)</label>
+                      <input
+                        type="number"
+                        id="suppressAfterCount"
+                        min="0"
+                        max="100"
+                        value={escalationForm.suppressAfterCount}
+                        onChange={(e) => setEscalationForm({ ...escalationForm, suppressAfterCount: parseInt(e.target.value) || 0 })}
+                        className="mt-1 block w-32 border border-gray-300 rounded-md shadow-sm py-2 px-3 text-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="suppressDurationMinutes" className="block text-sm text-gray-700">Suppress for (minutes)</label>
+                      <input
+                        type="number"
+                        id="suppressDurationMinutes"
+                        min="0"
+                        max="10080"
+                        value={escalationForm.suppressDurationMinutes}
+                        onChange={(e) => setEscalationForm({ ...escalationForm, suppressDurationMinutes: parseInt(e.target.value) || 0 })}
+                        className="mt-1 block w-32 border border-gray-300 rounded-md shadow-sm py-2 px-3 text-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                      />
+                    </div>
+                  </div>
+
+                  {check?.suppressedUntil && new Date(check.suppressedUntil) > new Date() && (
+                    <div className="mt-3 p-3 bg-amber-50 rounded-md text-sm text-amber-800">
+                      Alerts currently suppressed until {new Date(check.suppressedUntil).toLocaleString()}
+                    </div>
+                  )}
+
+                  <button
+                    onClick={handleSaveEscalation}
+                    disabled={savingEscalation}
+                    className="mt-4 inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+                  >
+                    {savingEscalation ? 'Saving…' : 'Save escalation settings'}
+                  </button>
+                </div>
 
               </div>
             </div>

--- a/frontend/src/pages/ChecksPage.jsx
+++ b/frontend/src/pages/ChecksPage.jsx
@@ -27,6 +27,7 @@ export default function ChecksPage({ user, onLogout }) {
     url: '',
     expectedStatusCode: 200,
     failureThreshold: 1,
+    tags: [],
   })
   const [creating, setCreating] = useState(false)
   const [availableChannels, setAvailableChannels] = useState([])
@@ -35,12 +36,16 @@ export default function ChecksPage({ user, onLogout }) {
   const [showTokenRotated, setShowTokenRotated] = useState(null)
   const [actionLoading, setActionLoading] = useState(null)
   const [selectedChecks, setSelectedChecks] = useState(new Set())
+  const [searchQuery, setSearchQuery] = useState('')
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [tagFilter, setTagFilter] = useState(null)
   const [bulkActionLoading, setBulkActionLoading] = useState(false)
   const [showQuickEdit, setShowQuickEdit] = useState(null)
   const [quickEditData, setQuickEditData] = useState({
     name: '',
     periodSeconds: 60, // 1 minute in seconds
     graceSeconds: 300, // 5 minutes in seconds
+    tags: [],
   })
   const [quickEditLoading, setQuickEditLoading] = useState(false)
   
@@ -122,7 +127,7 @@ export default function ChecksPage({ user, onLogout }) {
     setCreating(true)
     try {
       await api.createCheck(teamId, formData)
-      setFormData({ name: '', periodSeconds: 60, graceSeconds: 300, alertChannels: [], type: 'heartbeat', schedule: '', url: '', expectedStatusCode: 200, failureThreshold: 1 })
+      setFormData({ name: '', periodSeconds: 60, graceSeconds: 300, alertChannels: [], type: 'heartbeat', schedule: '', url: '', expectedStatusCode: 200, failureThreshold: 1, tags: [] })
       setShowCreateCheck(false)
       loadChecks()
       toast.success('Check created successfully')
@@ -172,11 +177,25 @@ export default function ChecksPage({ user, onLogout }) {
     setSelectedChecks(newSelected)
   }
 
+  const allTags = [...new Set(checks.flatMap(c => c.tags || []))].sort()
+
+  const filteredChecks = checks.filter(c => {
+    if (searchQuery && !c.name.toLowerCase().includes(searchQuery.toLowerCase())) return false
+    if (statusFilter !== 'all' && c.status !== statusFilter) return false
+    if (tagFilter && !(c.tags || []).includes(tagFilter)) return false
+    return true
+  })
+
+  const statusCounts = checks.reduce((acc, c) => {
+    acc[c.status] = (acc[c.status] || 0) + 1
+    return acc
+  }, {})
+
   function toggleSelectAll() {
-    if (selectedChecks.size === checks.length) {
+    if (selectedChecks.size === filteredChecks.length) {
       setSelectedChecks(new Set())
     } else {
-      setSelectedChecks(new Set(checks.map(c => c.checkId)))
+      setSelectedChecks(new Set(filteredChecks.map(c => c.checkId)))
     }
   }
 
@@ -234,6 +253,7 @@ export default function ChecksPage({ user, onLogout }) {
       name: check.name,
       periodSeconds: check.periodSeconds,
       graceSeconds: check.graceSeconds,
+      tags: check.tags || [],
     })
     setShowQuickEdit(check.checkId)
   }
@@ -517,6 +537,20 @@ export default function ChecksPage({ user, onLogout }) {
                 </div>
               )}
               
+              <div>
+                <label htmlFor="createTags" className="block text-sm font-medium text-gray-700">
+                  Tags <span className="text-gray-400 font-normal">(optional, comma-separated)</span>
+                </label>
+                <input
+                  type="text"
+                  id="createTags"
+                  value={(formData.tags || []).join(', ')}
+                  onChange={(e) => setFormData({ ...formData, tags: e.target.value.split(',').map(t => t.trim().toLowerCase()).filter(Boolean) })}
+                  placeholder="prod, backups, db"
+                  className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                />
+              </div>
+
               {/* Alert Channels Selection */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -625,20 +659,75 @@ export default function ChecksPage({ user, onLogout }) {
           </div>
         ) : (
           <div className="space-y-4">
+            {/* Search & Filters */}
+            <div className="bg-white shadow sm:rounded-lg p-4 space-y-3">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+                <input
+                  type="search"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search checks by name…"
+                  className="flex-1 border border-gray-300 rounded-md shadow-sm py-2 px-3 text-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                  aria-label="Search checks"
+                />
+                <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by status">
+                  {['all', 'up', 'late', 'pending', 'paused'].map((status) => (
+                    <button
+                      key={status}
+                      onClick={() => setStatusFilter(status)}
+                      className={`px-3 py-1.5 text-xs font-medium rounded-full border ${
+                        statusFilter === status
+                          ? 'bg-blue-600 text-white border-blue-600'
+                          : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                      }`}
+                    >
+                      {status === 'all' ? `All (${checks.length})` : `${status.charAt(0).toUpperCase()}${status.slice(1)} (${statusCounts[status] || 0})`}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {allTags.length > 0 && (
+                <div className="flex flex-wrap items-center gap-1" role="group" aria-label="Filter by tag">
+                  <span className="text-xs text-gray-500 mr-1">Tags:</span>
+                  {allTags.map((tag) => (
+                    <button
+                      key={tag}
+                      onClick={() => setTagFilter(tagFilter === tag ? null : tag)}
+                      className={`px-2 py-0.5 text-xs rounded-full border ${
+                        tagFilter === tag
+                          ? 'bg-indigo-600 text-white border-indigo-600'
+                          : 'bg-indigo-50 text-indigo-700 border-indigo-200 hover:bg-indigo-100'
+                      }`}
+                    >
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+              )}
+              {(searchQuery || statusFilter !== 'all' || tagFilter) && (
+                <p className="text-xs text-gray-500">
+                  Showing {filteredChecks.length} of {checks.length} checks
+                  <button onClick={() => { setSearchQuery(''); setStatusFilter('all'); setTagFilter(null) }} className="ml-2 text-blue-600 hover:underline">
+                    Clear filters
+                  </button>
+                </p>
+              )}
+            </div>
+
             {/* Bulk Actions Bar */}
-            {checks.length > 0 && (
+            {filteredChecks.length > 0 && (
               <div className="bg-white shadow sm:rounded-lg p-4">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-4">
                     <label className="flex items-center">
                       <input
                         type="checkbox"
-                        checked={selectedChecks.size === checks.length && checks.length > 0}
+                        checked={selectedChecks.size === filteredChecks.length && filteredChecks.length > 0}
                         onChange={toggleSelectAll}
                         className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
                       />
                       <span className="ml-2 text-sm text-gray-700">
-                        Select all ({selectedChecks.size} of {checks.length} selected)
+                        Select all ({selectedChecks.size} of {filteredChecks.length} selected)
                       </span>
                     </label>
                   </div>
@@ -669,7 +758,7 @@ export default function ChecksPage({ user, onLogout }) {
 
             <div className="bg-white shadow overflow-hidden sm:rounded-md">
               <ul className="divide-y divide-gray-200">
-                {checks.map((check) => (
+                {filteredChecks.map((check) => (
                 <li
                   key={check.checkId}
                   className="hover:bg-gray-50"
@@ -695,6 +784,11 @@ export default function ChecksPage({ user, onLogout }) {
                               HTTP
                             </span>
                           )}
+                          {(check.tags || []).map((tag) => (
+                            <span key={tag} className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-indigo-50 text-indigo-700 border border-indigo-200">
+                              {tag}
+                            </span>
+                          ))}
                           {check.alertTopics && check.alertTopics.length > 0 && (
                             <div className="flex items-center">
                               <Bell className="h-4 w-4 text-orange-500" title={`${check.alertTopics.length} alert topic(s) configured`} />
@@ -953,7 +1047,21 @@ export default function ChecksPage({ user, onLogout }) {
                     ⚠️ Grace period is longer than 2× the check period — you may miss alerts
                   </div>
                 )}
-                
+
+                <div>
+                  <label htmlFor="quickEditTags" className="block text-sm font-medium text-gray-700">
+                    Tags <span className="text-gray-400 font-normal">(optional, comma-separated)</span>
+                  </label>
+                  <input
+                    type="text"
+                    id="quickEditTags"
+                    value={(quickEditData.tags || []).join(', ')}
+                    onChange={(e) => setQuickEditData({ ...quickEditData, tags: e.target.value.split(',').map(t => t.trim().toLowerCase()).filter(Boolean) })}
+                    placeholder="prod, backups, db"
+                    className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                  />
+                </div>
+
                 <div className="flex space-x-3 pt-4">
                   <button
                     type="submit"

--- a/frontend/src/pages/TeamSettingsPage.jsx
+++ b/frontend/src/pages/TeamSettingsPage.jsx
@@ -34,16 +34,9 @@ export default function TeamSettingsPage({ user, onLogout }) {
   const [loading, setLoading] = useState(true)
   const [testingChannel, setTestingChannel] = useState(null)
   const [showAddMember, setShowAddMember] = useState(false)
-  const [showAddAlert, setShowAddAlert] = useState(false)
   const [newMemberEmail, setNewMemberEmail] = useState('')
   const [newMemberRole, setNewMemberRole] = useState('member')
-  const [newAlertName, setNewAlertName] = useState('')
-  const [newAlertDisplayName, setNewAlertDisplayName] = useState('')
-  const [newAlertShared, setNewAlertShared] = useState(false)
-  const [newChannelType, setNewChannelType] = useState('mattermost')
-  const [newChannelConfig, setNewChannelConfig] = useState({})
   const [channels, setChannels] = useState([])
-  const [editingChannel, setEditingChannel] = useState(null)
   const [mattermostWebhook, setMattermostWebhook] = useState('')
   const [mattermostLoading, setMattermostLoading] = useState(false)
   const [mattermostWebhooks, setMattermostWebhooks] = useState([])
@@ -226,32 +219,6 @@ export default function TeamSettingsPage({ user, onLogout }) {
     }
   }
 
-  async function handleAddAlert(e) {
-    e.preventDefault()
-    if (!newAlertName.trim() || !newAlertDisplayName.trim()) return
-
-    try {
-      const channelData = {
-        name: newAlertName.trim(),
-        displayName: newAlertDisplayName.trim(),
-        type: newChannelType,
-        configuration: newChannelConfig,
-        shared: newAlertShared
-      }
-
-      await api.createAlertChannel(teamId, channelData)
-      setNewAlertName('')
-      setNewAlertDisplayName('')
-      setNewChannelType('mattermost')
-      setNewChannelConfig({})
-      setNewAlertShared(false)
-      setShowAddAlert(false)
-      toast.success('Alert channel created')
-      loadChannels()
-    } catch (error) {
-      toast.error('Failed to create channel: ' + error.message)
-    }
-  }
 
   async function loadChannels() {
     try {
@@ -378,23 +345,6 @@ export default function TeamSettingsPage({ user, onLogout }) {
     })
   }
 
-  function handleDeleteChannel(channelId) {
-    setConfirmState({
-      title: 'Delete Alert Channel',
-      message: 'Are you sure you want to delete this alert channel? Checks using it will stop sending notifications through it.',
-      confirmLabel: 'Delete',
-      destructive: true,
-      onConfirm: async () => {
-        try {
-          await api.deleteAlertChannel(teamId, channelId)
-          toast.success('Alert channel deleted')
-          loadChannels()
-        } catch (error) {
-          toast.error('Failed to delete channel: ' + error.message)
-        }
-      },
-    })
-  }
 
   async function handleTestChannel(channelId) {
     setTestingChannel(channelId)
@@ -408,210 +358,8 @@ export default function TeamSettingsPage({ user, onLogout }) {
     }
   }
 
-  function renderChannelConfiguration() {
-    if (newChannelType === 'sns') {
-      return (
-        <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
-          <p className="text-sm text-blue-700">
-            SNS topic will be created automatically when you create this channel.
-          </p>
-        </div>
-      )
-    }
 
-    if (newChannelType === 'mattermost') {
-      return (
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Webhook URL</label>
-          <input
-            type="url"
-            value={newChannelConfig.webhook_url || ''}
-            onChange={(e) => setNewChannelConfig({ webhook_url: e.target.value })}
-            placeholder="https://chat.example.com/hooks/your-webhook-id"
-            className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-            required
-          />
-        </div>
-      )
-    }
 
-    if (newChannelType === 'webhook') {
-      return (
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Webhook URL</label>
-          <input
-            type="url"
-            value={newChannelConfig.webhook_url || ''}
-            onChange={(e) => setNewChannelConfig({ webhook_url: e.target.value })}
-            placeholder="https://hooks.example.com/alerts"
-            className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-            required
-          />
-        </div>
-      )
-    }
-
-    if (newChannelType === 'email') {
-      return (
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Recipients</label>
-          <input
-            type="text"
-            value={(newChannelConfig.recipients || []).join(', ')}
-            onChange={(e) => setNewChannelConfig({ recipients: e.target.value.split(',').map(s => s.trim()).filter(Boolean) })}
-            placeholder="oncall@example.com, sre-team@example.com"
-            className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-            required
-          />
-          <p className="mt-1 text-xs text-gray-500">Comma-separated, up to 20 addresses.</p>
-        </div>
-      )
-    }
-
-    if (newChannelType === 'telegram') {
-      return (
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700">Bot Token</label>
-            <input
-              type="text"
-              value={newChannelConfig.bot_token || ''}
-              onChange={(e) => setNewChannelConfig({ ...newChannelConfig, bot_token: e.target.value })}
-              placeholder="123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
-              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700">Chat ID</label>
-            <input
-              type="text"
-              value={newChannelConfig.chat_id || ''}
-              onChange={(e) => setNewChannelConfig({ ...newChannelConfig, chat_id: e.target.value })}
-              placeholder="-1001234567890"
-              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              required
-            />
-          </div>
-        </div>
-      )
-    }
-
-    return null
-  }
-
-  async function handleUpdateChannel(e) {
-    e.preventDefault()
-
-    try {
-      const updateData = {
-        displayName: editingChannel.displayName,
-        configuration: editingChannel.configuration,
-        shared: editingChannel.shared
-      }
-
-      await api.updateAlertChannel(teamId, editingChannel.channelId, updateData)
-      setEditingChannel(null)
-      toast.success('Channel updated')
-      loadChannels()
-    } catch (error) {
-      toast.error('Failed to update channel: ' + error.message)
-    }
-  }
-
-  function renderEditChannelConfiguration() {
-    if (!editingChannel) return null
-
-    if (editingChannel.type === 'sns') {
-      return (
-        <div>
-          <label className="block text-sm font-medium text-gray-700">SNS Topic ARN</label>
-          <input
-            type="text"
-            value={editingChannel.configuration?.topic_arn || ''}
-            onChange={(e) => setEditingChannel({
-              ...editingChannel,
-              configuration: { ...editingChannel.configuration, topic_arn: e.target.value }
-            })}
-            className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-            required
-          />
-        </div>
-      )
-    }
-
-    if (editingChannel.type === 'mattermost' || editingChannel.type === 'webhook') {
-      return (
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Webhook URL</label>
-          <input
-            type="url"
-            value={editingChannel.configuration?.webhook_url || ''}
-            onChange={(e) => setEditingChannel({
-              ...editingChannel,
-              configuration: { ...editingChannel.configuration, webhook_url: e.target.value }
-            })}
-            className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-            required
-          />
-        </div>
-      )
-    }
-
-    if (editingChannel.type === 'email') {
-      return (
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Recipients</label>
-          <input
-            type="text"
-            value={(editingChannel.configuration?.recipients || []).join(', ')}
-            onChange={(e) => setEditingChannel({
-              ...editingChannel,
-              configuration: { ...editingChannel.configuration, recipients: e.target.value.split(',').map(s => s.trim()).filter(Boolean) }
-            })}
-            className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-            required
-          />
-          <p className="mt-1 text-xs text-gray-500">Comma-separated, up to 20 addresses.</p>
-        </div>
-      )
-    }
-
-    if (editingChannel.type === 'telegram') {
-      return (
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700">Bot Token</label>
-            <input
-              type="text"
-              value={editingChannel.configuration?.bot_token || ''}
-              onChange={(e) => setEditingChannel({
-                ...editingChannel,
-                configuration: { ...editingChannel.configuration, bot_token: e.target.value }
-              })}
-              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700">Chat ID</label>
-            <input
-              type="text"
-              value={editingChannel.configuration?.chat_id || ''}
-              onChange={(e) => setEditingChannel({
-                ...editingChannel,
-                configuration: { ...editingChannel.configuration, chat_id: e.target.value }
-              })}
-              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              required
-            />
-          </div>
-        </div>
-      )
-    }
-
-    return null
-  }
 
   async function handleDeleteTeam() {
     if (deleteConfirmText !== team?.name) {
@@ -879,93 +627,17 @@ export default function TeamSettingsPage({ user, onLogout }) {
                   Alert Channels
                 </h3>
                 <p className="mt-1 max-w-2xl text-sm text-gray-500">
-                  Configure notification channels for alerts (SNS, Mattermost, Webhook, Telegram).
+                  Channels this team can notify. Create, edit, and delete channels on the Alert Channels page.
                 </p>
               </div>
               <button
-                onClick={() => setShowAddAlert(true)}
+                onClick={() => navigate(`/teams/${teamId}/channels`)}
                 className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700"
               >
-                <Plus className="h-4 w-4 mr-2" />
-                Add Channel
+                <Settings className="h-4 w-4 mr-2" />
+                Manage Channels
               </button>
             </div>
-
-            {showAddAlert && (
-              <div className="border-t border-gray-200 px-4 py-4 bg-gray-50">
-                <form onSubmit={handleAddAlert} className="space-y-4">
-                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700">Channel Name</label>
-                      <input
-                        type="text"
-                        value={newAlertName}
-                        onChange={(e) => setNewAlertName(e.target.value)}
-                        placeholder="my-alerts"
-                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                        required
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700">Display Name</label>
-                      <input
-                        type="text"
-                        value={newAlertDisplayName}
-                        onChange={(e) => setNewAlertDisplayName(e.target.value)}
-                        placeholder="My Alerts Channel"
-                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                        required
-                      />
-                    </div>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700">Channel Type</label>
-                    <select
-                      value={newChannelType}
-                      onChange={(e) => setNewChannelType(e.target.value)}
-                      className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    >
-                      <option value="sns">SNS Topic</option>
-                      <option value="mattermost">Mattermost</option>
-                      <option value="webhook">Webhook</option>
-                      <option value="telegram">Telegram</option>
-                      <option value="email">Email</option>
-                    </select>
-                  </div>
-
-                  {renderChannelConfiguration()}
-
-                  <div className="flex items-center">
-                    <input
-                      type="checkbox"
-                      checked={newAlertShared}
-                      onChange={(e) => setNewAlertShared(e.target.checked)}
-                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                    />
-                    <label className="ml-2 block text-sm text-gray-900">
-                      Shared channel (can be used by other teams)
-                    </label>
-                  </div>
-
-                  <div className="flex space-x-3">
-                    <button
-                      type="submit"
-                      className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700"
-                    >
-                      Create Channel
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setShowAddAlert(false)}
-                      className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </form>
-              </div>
-            )}
 
             <div className="border-t border-gray-200">
               {channels.length === 0 ? (
@@ -995,11 +667,6 @@ export default function TeamSettingsPage({ user, onLogout }) {
                             </div>
                             <div className="text-sm text-gray-500">
                               {channel.type.toUpperCase()} • {channel.name}
-                              {channel.shared && (
-                                <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                                  Shared
-                                </span>
-                              )}
                             </div>
                           </div>
                         </div>
@@ -1013,16 +680,10 @@ export default function TeamSettingsPage({ user, onLogout }) {
                             <PlayCircle className="h-4 w-4" />
                           </button>
                           <button
-                            onClick={() => setEditingChannel(channel)}
-                            className="text-blue-600 hover:text-blue-800"
+                            onClick={() => navigate(`/teams/${teamId}/channels`)}
+                            className="text-blue-600 hover:text-blue-800 text-sm"
                           >
-                            <Settings className="h-4 w-4" />
-                          </button>
-                          <button
-                            onClick={() => handleDeleteChannel(channel.channelId)}
-                            className="text-red-600 hover:text-red-800"
-                          >
-                            <Trash2 className="h-4 w-4" />
+                            Edit on Channels page
                           </button>
                         </div>
                       </div>
@@ -1030,59 +691,6 @@ export default function TeamSettingsPage({ user, onLogout }) {
                   ))}
                 </ul>
               )}
-            </div>
-          </div>
-        )}
-
-        {/* Edit Channel Modal */}
-        {editingChannel && (
-          <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
-            <div className="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
-              <div className="mt-3">
-                <h3 className="text-lg font-medium text-gray-900 mb-4">Edit Alert Channel</h3>
-                <form onSubmit={handleUpdateChannel} className="space-y-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700">Display Name</label>
-                    <input
-                      type="text"
-                      value={editingChannel.displayName}
-                      onChange={(e) => setEditingChannel({...editingChannel, displayName: e.target.value})}
-                      className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                      required
-                    />
-                  </div>
-
-                  {renderEditChannelConfiguration()}
-
-                  <div className="flex items-center">
-                    <input
-                      type="checkbox"
-                      checked={editingChannel.shared}
-                      onChange={(e) => setEditingChannel({...editingChannel, shared: e.target.checked})}
-                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                    />
-                    <label className="ml-2 block text-sm text-gray-900">
-                      Shared channel (can be used by other teams)
-                    </label>
-                  </div>
-
-                  <div className="flex space-x-3">
-                    <button
-                      type="submit"
-                      className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700"
-                    >
-                      Update Channel
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setEditingChannel(null)}
-                      className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </form>
-              </div>
             </div>
           </div>
         )}

--- a/frontend/src/pages/TeamSettingsPage.jsx
+++ b/frontend/src/pages/TeamSettingsPage.jsx
@@ -43,6 +43,8 @@ export default function TeamSettingsPage({ user, onLogout }) {
   const [newWebhookUrl, setNewWebhookUrl] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [confirmState, setConfirmState] = useState(null)
+  const [auditEvents, setAuditEvents] = useState([])
+  const [auditLoading, setAuditLoading] = useState(false)
   const [deleteConfirmText, setDeleteConfirmText] = useState('')
   const [deleteLoading, setDeleteLoading] = useState(false)
   const [apiTokens, setApiTokens] = useState([])
@@ -64,6 +66,8 @@ export default function TeamSettingsPage({ user, onLogout }) {
       loadChannels()
     } else if (activeTab === 'tokens') {
       loadApiTokens()
+    } else if (activeTab === 'audit') {
+      loadAuditLog()
     } else if (activeTab === 'reports') {
       loadReports()
       loadReportChecks()
@@ -95,6 +99,18 @@ export default function TeamSettingsPage({ user, onLogout }) {
     } catch {
     } finally {
       setLoading(false)
+    }
+  }
+
+  async function loadAuditLog() {
+    setAuditLoading(true)
+    try {
+      const data = await api.getTeamAuditLog(teamId)
+      setAuditEvents(Array.isArray(data) ? data : [])
+    } catch {
+      setAuditEvents([])
+    } finally {
+      setAuditLoading(false)
     }
   }
 
@@ -462,6 +478,17 @@ export default function TeamSettingsPage({ user, onLogout }) {
             >
               <FileText className="h-4 w-4 inline mr-2" />
               Reports
+            </button>
+            <button
+              onClick={() => setActiveTab('audit')}
+              className={`py-2 px-1 border-b-2 font-medium text-sm ${
+                activeTab === 'audit'
+                  ? 'border-blue-500 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              }`}
+            >
+              <FileText className="h-4 w-4 inline mr-2" />
+              Audit Log
             </button>
             <button
               onClick={() => setActiveTab('danger')}
@@ -931,6 +958,52 @@ export default function TeamSettingsPage({ user, onLogout }) {
         )}
 
         {/* Danger Zone Tab */}
+        {activeTab === 'audit' && (
+          <div className="bg-white shadow overflow-hidden sm:rounded-lg">
+            <div className="px-4 py-5 sm:px-6">
+              <h3 className="text-lg leading-6 font-medium text-gray-900">Audit Log</h3>
+              <p className="mt-1 max-w-2xl text-sm text-gray-500">
+                Administrative actions in this team — who did what, and when. Admins only.
+              </p>
+            </div>
+            <div className="border-t border-gray-200">
+              {auditLoading ? (
+                <div className="px-4 py-8 text-center">
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+                </div>
+              ) : auditEvents.length === 0 ? (
+                <div className="px-4 py-8 text-center text-sm text-gray-500">
+                  No recorded actions yet
+                </div>
+              ) : (
+                <ul className="divide-y divide-gray-200">
+                  {auditEvents.map((event) => (
+                    <li key={event.eventId} className="px-4 py-3">
+                      <div className="flex items-center justify-between">
+                        <div className="min-w-0">
+                          <p className="text-sm text-gray-900">
+                            <span className="font-medium">{event.actorEmail}</span>
+                            <span className="mx-1.5 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">
+                              {event.action}
+                            </span>
+                            {event.targetName || event.targetId}
+                          </p>
+                          {event.detail && (
+                            <p className="text-xs text-gray-500 mt-0.5">{event.detail}</p>
+                          )}
+                        </div>
+                        <span className="text-sm text-gray-500 flex-shrink-0 ml-4" title={new Date(event.createdAt).toLocaleString()}>
+                          {new Date(event.createdAt).toLocaleString()}
+                        </span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+
         {activeTab === 'danger' && (
           <div className="bg-white shadow overflow-hidden sm:rounded-lg">
             <div className="px-4 py-5 sm:px-6">

--- a/infra/aws/lambdas.tf
+++ b/infra/aws/lambdas.tf
@@ -170,6 +170,7 @@ resource "aws_lambda_function" "late_detector" {
   environment {
     variables = {
       DYNAMODB_TABLE = aws_dynamodb_table.pulsechecks.name
+      HEARTBEAT_URL  = var.heartbeat_url
       SMTP_HOST      = var.smtp_host
       SMTP_PORT      = var.smtp_port
       SMTP_USERNAME  = var.smtp_username

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -99,3 +99,9 @@ variable "smtp_from" {
   type        = string
   default     = ""
 }
+
+variable "heartbeat_url" {
+  description = "External dead-man's-switch URL pinged after each late-detection run (optional)"
+  type        = string
+  default     = ""
+}

--- a/infra/gcp/cloudrun.tf
+++ b/infra/gcp/cloudrun.tf
@@ -66,6 +66,13 @@ resource "google_cloud_run_service" "pulsechecks_api" {
           value = "https://${var.domain_name}"
         }
 
+        # Dead-man's-switch: external heartbeat pinged after each
+        # late-detection run (optional)
+        env {
+          name  = "HEARTBEAT_URL"
+          value = var.heartbeat_url
+        }
+
         # SMTP for email alert channels (optional — email channels are
         # unavailable until these are set)
         env {

--- a/infra/gcp/firestore.tf
+++ b/infra/gcp/firestore.tf
@@ -97,3 +97,21 @@ resource "google_firestore_index" "alert_deliveries_check_history" {
 
 # Single-field indexes for token/teamId/alertAfterAt are managed by Firestore automatically.
 # Add google_firestore_index resources only for true composite index requirements.
+
+# Composite index for the HTTP poller's due-check query
+resource "google_firestore_index" "http_checks_due" {
+  project    = var.gcp_project_id
+  database   = google_firestore_database.pulsechecks.name
+  collection = "checks"
+
+  fields {
+    field_path = "type"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "nextDueAt"
+    order      = "ASCENDING"
+  }
+
+  depends_on = [google_firestore_database.pulsechecks]
+}

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -145,3 +145,9 @@ variable "smtp_from" {
   type        = string
   default     = ""
 }
+
+variable "heartbeat_url" {
+  description = "External dead-man's-switch URL pinged after each late-detection run (optional)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Completes the remaining reliability/usability roadmap:

**Tags, search & filtering (item 2)** — checks support up to 10 tags, persisted on both DB layers; the checks list gets a search box, status filter chips with counts, and tag filters; tags are editable in the create form and quick-edit modal. Along the way: the DynamoDB check mapper was missing fields Firestore already persisted (slug, `expectedString`, `failureThreshold`, suppression state) — those features silently didn't work on AWS; now at parity.

**Escalation/suppression UI + channel consolidation (item 3)** — the backend's escalation and suppression engine is finally configurable from the check detail page (escalate-after minutes, dedicated escalation channels, suppress-after-N for M minutes, active-suppression notice). Setting 0 disables — previously escalation could never be turned off via the API. Channel CRUD is consolidated to the Alert Channels page; Team Settings' alerts tab is a read-only summary with test buttons, its duplicate forms and double "Shared" badge removed.

**HTTP poller + dead-man's-switch (item 4)** — due-filtering moved into the database (new Firestore `(type, nextDueAt)` composite index; server-side filter on DynamoDB), fixing a bug where `nextDueAt` was parsed as ISO when HTTP checks store epoch seconds, so **every HTTP check was being polled every minute** regardless of period. Probes now run under a concurrency cap (10). New `HEARTBEAT_URL` setting pings an external monitor after each late-detection run so you learn when PulseChecks' own loop stops — Terraform variables on both clouds.

**Team audit log (item 5)** — every admin action recorded (check CRUD/pause/resume/token-rotate, channel CRUD, member invite/add/remove/role change, team delete, API token create/revoke) with actor, target, and detail; 90-day TTL; best-effort so audit-store failures can't break the underlying action. Admin-only `GET /teams/{id}/audit` endpoint and an Audit Log tab in Team Settings.

**Multi-region plan (item 6)** — `docs/plans/multi-region-ingestion.md`. Written as a plan rather than code because Firestore's region is immutable after creation: it's an export/import migration to `nam5` plus an additive second Cloud Run region behind the existing global LB, with availability math (~99.98–99.99% for ingestion), verification drills, and explicit non-goals.

## Testing

- Backend: 400 passed, 8 skipped (new audit, heartbeat, poller-due tests)
- Frontend: 64 passed, 1 skipped; production build verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi)_