### PR TITLE
Fix CI: Terraform 1.6.0's expired GPG key breaks provider install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,10 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.6.0
+          # Track latest like GitLab CI does (hashicorp/terraform:latest).
+          # Old pinned binaries (1.6.0) bundle an expired HashiCorp GPG key
+          # and fail provider installs with "openpgp: key expired".
+          terraform_version: latest
 
       - name: Terraform Format Check
         working-directory: infra/${{ matrix.cloud }}


### PR DESCRIPTION
## Summary

The remaining GitHub Actions failures are **not test failures** — backend and frontend suites pass on every recent run. The red job is `Terraform Validation (gcp)`: the workflow pins Terraform **1.6.0**, whose bundled HashiCorp provider-signing GPG key has expired, so `terraform init` fails with `openpgp: key expired` while installing `hashicorp/google`.

Fix: track `terraform_version: latest` in the validation job, matching what GitLab CI already does for production deploys (`hashicorp/terraform:latest`) — which is why deploys were unaffected.

## Testing

- Backend: 400 passed, 8 skipped locally; frontend: 64 passed — unchanged
- The workflow run triggered by this merge is the real verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi)_