### PR TITLE
Security: fix CSV formula injection in report exports

### DIFF
--- a/backend/app/routers/alerts.py
+++ b/backend/app/routers/alerts.py
@@ -12,6 +12,9 @@ from ..models import (
     Permission,
 )
 from ..config import get_settings
+from ..logging_config import get_logger
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/teams/{team_id}/alerts", tags=["alerts"])
 
@@ -130,19 +133,19 @@ async def list_alert_topics(
                         ))
                     except ClientError as e:
                         # Skip topics we can't access
-                        print(f"Warning: Could not access topic {topic_arn}: {e}")
+                        logger.warning("Could not access topic %s: %s", topic_arn, e)
                         continue
 
         return topics
 
     except ClientError as e:
-        print(f"Error listing SNS topics: {e}")
+        logger.error("Error listing SNS topics: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to list alert topics: {str(e)}"
         )
     except Exception as e:
-        print(f"Unexpected error listing alert topics: {e}")
+        logger.error("Unexpected error listing alert topics: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list alert topics"

--- a/backend/app/routers/channels.py
+++ b/backend/app/routers/channels.py
@@ -12,6 +12,9 @@ from ..config import get_settings
 from ..ssrf_utils import validate_webhook_url_strict, SSRFValidationError
 from ..posthog_client import get_posthog_client, new_context, identify_context
 from ..audit import record_audit
+from ..logging_config import get_logger
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/teams/{team_id}/channels", tags=["alert-channels"])
 
@@ -225,7 +228,7 @@ async def delete_alert_channel(
             sns.delete_topic(TopicArn=topic_arn)
         except ClientError as e:
             # Log but don't fail if topic deletion fails
-            print(f"Warning: Failed to delete SNS topic {topic_arn}: {e}")
+            logger.warning("Failed to delete SNS topic %s: %s", topic_arn, e)
     
     await db.delete_alert_channel(team_id, channel_id)
     await record_audit(db, team_id, current_user, "channel.deleted", "channel", channel_id, channel.display_name, detail=f"type: {channel.type.value}")

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -188,6 +188,16 @@ def _report_rows(report_type: str, payload: dict) -> list[dict]:
     return rows
 
 
+def _csv_safe(value):
+    """Neutralize CSV formula injection (OWASP): a cell whose text begins with
+    =, +, -, @, or a control char is executed as a formula by Excel/Sheets.
+    User-controlled fields (e.g. check names) flow into these cells, so prefix
+    any such value with a single quote to force it to render as text."""
+    if isinstance(value, str) and value and value[0] in ("=", "+", "-", "@", "\t", "\r", "\n"):
+        return "'" + value
+    return value
+
+
 def _render_report_content(report_type: str, fmt: str, payload: dict) -> tuple[str, str]:
     if fmt == "json":
         return json.dumps(payload, indent=2), "application/json"
@@ -198,9 +208,9 @@ def _render_report_content(report_type: str, fmt: str, payload: dict) -> tuple[s
     writer = csv.DictWriter(stream, fieldnames=fieldnames)
     writer.writeheader()
     if rows:
-        writer.writerows(rows)
+        writer.writerows({k: _csv_safe(v) for k, v in row.items()} for row in rows)
     else:
-        writer.writerow({"team_id": payload["teamId"], "report_type": payload["reportType"], "from": payload["from"], "to": payload["to"]})
+        writer.writerow({"team_id": _csv_safe(payload["teamId"]), "report_type": payload["reportType"], "from": payload["from"], "to": payload["to"]})
     return stream.getvalue(), "text/csv"
 
 

--- a/backend/tests/test_csv_injection.py
+++ b/backend/tests/test_csv_injection.py
@@ -1,0 +1,39 @@
+"""Regression tests for CSV formula injection in report exports."""
+from app.routers.reports import _csv_safe, _render_report_content
+
+
+class TestCsvSafe:
+    def test_formula_prefixes_are_neutralized(self):
+        for payload in ("=1+1", "+1", "-1", "@SUM(A1)", "=cmd|'/c calc'!A1",
+                        "=HYPERLINK(\"http://evil\",\"x\")", "\ttab", "\rcr"):
+            out = _csv_safe(payload)
+            assert out.startswith("'"), f"{payload!r} was not neutralized"
+
+    def test_normal_values_unchanged(self):
+        for payload in ("Nightly Backup", "check-1", "up", "prod db", "500", ""):
+            assert _csv_safe(payload) == payload
+
+    def test_non_strings_unchanged(self):
+        assert _csv_safe(42) == 42
+        assert _csv_safe(None) is None
+        assert _csv_safe(3.14) == 3.14
+
+
+class TestReportCsvRendering:
+    def test_malicious_check_name_is_escaped_in_csv(self):
+        payload = {
+            "teamId": "team-1", "reportType": "summary", "from": "a", "to": "b",
+            "checks": [{
+                "checkId": "c1", "name": "=cmd|'/c calc'!A1", "type": "cron", "status": "up",
+                "uptimePct": 99.9, "downtimeMinutes": 1, "excludedMaintenanceMinutes": 0,
+                "totalFailures": 0, "mostCommonCode": None, "avgResponseMs": 10,
+                "p95ResponseMs": 20, "latestResponseMs": 15,
+            }],
+        }
+        content, ctype = _render_report_content("summary", "csv", payload)
+        assert ctype == "text/csv"
+        # The dangerous cell must be quoted, never emitted starting with '='
+        assert "'=cmd" in content
+        for line in content.splitlines()[1:]:
+            first_cell = line.split(",")[0].strip('"')
+            assert not first_cell.startswith("=")


### PR DESCRIPTION
## Summary

Comprehensive security audit of the whole codebase (not just a diff). One real vulnerability found and fixed, plus minor logging hygiene. Everything else reviewed came back clean — details below.

### Fixed: CSV formula injection (report exports) — the one real finding
Report CSV exports wrote user-controlled fields — most importantly **check names, which have no charset restriction** — directly into cells. A check named `=cmd|'/c calc'!A1` or `=HYPERLINK("http://evil","click")` executes as a formula when an SRE opens the report in Excel or Google Sheets, enabling data exfiltration or command execution on the analyst's machine.

`_csv_safe()` now prefixes any cell beginning with `=`, `+`, `-`, `@`, or a control character with a single quote (OWASP guidance), applied to every CSV cell. JSON reports are unaffected (not formula-injectable). Covered by new `test_csv_injection.py`.

### Also: logging hygiene
Converted stray `print()` calls in `alerts.py`/`channels.py` to structured logging so exception detail no longer lands on stdout unstructured.

## What was audited and found clean

- **Secrets**: no hardcoded keys/tokens/passwords; no `.env`/`.pem`/`.key`/tfvars tracked; SDKs read from env.
- **AuthN/AuthZ**: JWT verified with email-verification + domain allowlist enforced; API tokens SHA-256 hashed with expiry checked; auth fails closed; every team route gates on `check_team_access` with role permissions.
- **Injection**: no SQL (NoSQL key-value stores), no `eval`/`exec`/`os.system`/`subprocess`/`pickle`/`yaml.load`; ping error codes regex-validated; cron parsed by croniter; report type/format whitelisted.
- **XSS/CSRF**: React auto-escaping, no `dangerouslySetInnerHTML`; token auth (no ambient cookies) so CSRF is not applicable.
- **SSRF**: webhook URLs validated (private ranges, loopback, link-local, cloud metadata endpoints blocked) at both channel-creation and send-time; HTTP poller re-validates and uses `follow_redirects=False`.
- **Deserialization/file upload**: none; reports are generated server-side, downloaded with a quoted server-generated filename.
- **Crypto/secrets**: PyJWT 2.10.1, cryptography 44.0.0 (current, post algorithm-confusion fixes); OIDC validated against Google certs with audience+issuer+SA checks.
- **IaC**: Docker images run as non-root `appuser`; Firestore rules deny-all (backend enforces); DynamoDB/Firestore PITR enabled.
- **CI/CD**: workflows trigger on `pull_request` (not `pull_request_target`); no untrusted `github.event.*` interpolated into `run:` steps; GITHUB_TOKEN read-only.
- **Headers/CORS**: `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` set; CORS origins derived from config, not wildcard.
- **DoS**: ping payloads capped at 100 KB; per-check failure thresholds; edge throttling (Cloud Armor) on GCP. Residual: in-app rate limiter is per-process (documented) — rely on API Gateway/Cloud Armor for global limits.

## Residual items (not fixed — by design or accepted, noted for the record)

- **DNS-rebinding TOCTOU on outbound webhooks**: validate-then-send leaves a small window where a hostile host could re-resolve to a blocked IP. Fully closing it needs resolved-IP pinning or an egress proxy; the practical risk is bounded (channels are configured by trusted team-EDIT members targeting their own endpoints, and cloud metadata needs a header on GCP). Recommend network-level egress policy in front of the metadata IP.
- **In-app rate limiter is per-instance** — already documented in the middleware; global enforcement belongs at the edge.

## Testing

- Backend: 404 passed, 8 skipped (includes new CSV-injection tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi)_