### PR TITLE
Per-IP edge rate limiting on both clouds; fix in-app limiter keying

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,6 +34,14 @@ class Settings(BaseSettings):
     debug: bool = False
     ping_retention_days: int = 90
 
+    # How many trailing X-Forwarded-For entries were appended by
+    # infrastructure we trust. 0 = ignore XFF (use the socket peer, correct
+    # on Lambda where API Gateway supplies the real source IP); 1 = Cloud Run
+    # reached directly (Cloud Run appends the caller's IP); 2 = Cloud Run
+    # behind the global HTTPS LB (GFE appends client-ip, lb-ip). Anything
+    # earlier in the header is client-supplied and must not be trusted.
+    trusted_proxy_hops: int = 0
+
     # Dead-man's-switch: external heartbeat URL pinged after every
     # successful late-detection run. Point this at an independent
     # monitor (e.g. a healthchecks.io check) so you find out when

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -79,11 +79,32 @@ logger.warning(
     "use API Gateway throttling or a shared store for global enforcement."
 )
 
+def get_client_ip(request: Request) -> str:
+    """Resolve the real client IP for rate-limit keying.
+
+    Behind Cloud Run / the global LB, request.client.host is the proxy's
+    address — keying on it would put every user in one shared bucket
+    (either throttling everyone together or nobody meaningfully). When
+    TRUSTED_PROXY_HOPS is set, take the client IP from X-Forwarded-For,
+    counting only the trailing entries appended by our own trusted
+    infrastructure; anything earlier is attacker-controlled.
+    """
+    from .config import get_settings
+    hops = get_settings().trusted_proxy_hops
+    if hops > 0:
+        forwarded = request.headers.get("x-forwarded-for", "")
+        if forwarded:
+            entries = [entry.strip() for entry in forwarded.split(",") if entry.strip()]
+            if len(entries) >= hops:
+                return entries[-hops]
+    return request.client.host if request.client else "unknown"
+
+
 async def rate_limit_middleware(request: Request, call_next):
     """Rate limiting middleware."""
     # Get client IP
-    client_ip = request.client.host if request.client else "unknown"
-    
+    client_ip = get_client_ip(request)
+
     # Choose appropriate limiter
     if request.url.path.startswith("/ping/"):
         limiter = ping_limiter

--- a/backend/tests/test_client_ip_keying.py
+++ b/backend/tests/test_client_ip_keying.py
@@ -1,0 +1,48 @@
+"""Tests for rate-limiter client IP resolution behind trusted proxies."""
+from unittest.mock import MagicMock, patch
+
+from app.middleware import get_client_ip
+
+
+def _request(peer="10.0.0.5", xff=None):
+    request = MagicMock()
+    request.client.host = peer
+    request.headers = {"x-forwarded-for": xff} if xff else {}
+    return request
+
+
+def _settings(hops):
+    settings = MagicMock()
+    settings.trusted_proxy_hops = hops
+    return settings
+
+
+class TestGetClientIp:
+    def test_hops_zero_uses_socket_peer(self):
+        with patch("app.config.get_settings", return_value=_settings(0)):
+            assert get_client_ip(_request(peer="1.2.3.4", xff="9.9.9.9")) == "1.2.3.4"
+
+    def test_cloud_run_direct_uses_last_entry(self):
+        # Cloud Run appends the caller's IP as the last XFF entry
+        with patch("app.config.get_settings", return_value=_settings(1)):
+            assert get_client_ip(_request(xff="6.6.6.6, 1.2.3.4")) == "1.2.3.4"
+
+    def test_behind_glb_uses_second_from_last(self):
+        # GFE appends "<client-ip>, <lb-ip>" — client is second-from-last
+        with patch("app.config.get_settings", return_value=_settings(2)):
+            assert get_client_ip(_request(xff="spoofed, 1.2.3.4, 130.211.0.1")) == "1.2.3.4"
+
+    def test_spoofed_prefix_entries_are_ignored(self):
+        # Attacker prepends fake IPs — only trailing trusted hops count
+        with patch("app.config.get_settings", return_value=_settings(2)):
+            xff = "8.8.8.8, 9.9.9.9, 1.2.3.4, 130.211.0.1"
+            assert get_client_ip(_request(xff=xff)) == "1.2.3.4"
+
+    def test_short_header_falls_back_to_peer(self):
+        # Fewer entries than trusted hops → misconfiguration; fail safe to peer
+        with patch("app.config.get_settings", return_value=_settings(2)):
+            assert get_client_ip(_request(peer="10.1.1.1", xff="1.2.3.4")) == "10.1.1.1"
+
+    def test_missing_header_falls_back_to_peer(self):
+        with patch("app.config.get_settings", return_value=_settings(2)):
+            assert get_client_ip(_request(peer="10.1.1.1")) == "10.1.1.1"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -51,6 +51,65 @@ curl -X POST https://api.pulsechecks.example.com/ping/test-token \
   -d "Health check test"
 ```
 
+## Rate Limiting Architecture
+
+Rate limiting is enforced **at the cloud edge, per client IP** — never as a
+single shared bucket, and never only inside the app. The in-app limiter is
+defense-in-depth, not the primary control (a per-instance limiter cannot see
+global traffic in a serverless deployment).
+
+### GCP (primary): Cloud Armor on the global HTTPS LB
+
+With `edge_throttling_enabled = true` (default), all public traffic flows
+through the global external HTTPS load balancer, where Cloud Armor enforces:
+
+| Rule | Scope | Limit | Action |
+|---|---|---|---|
+| 900 | Management API (`!/ping/*`, `!/health`) | `edge_throttle_api_requests_per_minute`/min **per IP** | 429 |
+| 1000 | All paths | `edge_throttle_requests_per_second`/s **per IP** | 429 |
+| 1010 | All paths | `edge_throttle_burst`/min **per IP** | ban for `edge_throttle_ban_duration_seconds` |
+
+Design invariants:
+- **`enforce_on_key = "IP"` on every rule.** A keyless (global-bucket)
+  throttle is worse than none: one flooder exhausts the shared budget and
+  legitimate ping traffic becomes the collateral damage.
+- **Cloud Run ingress is locked to `internal-and-cloud-load-balancing`**,
+  so the `run.app` URL cannot be used to bypass Cloud Armor. Cloud
+  Scheduler's OIDC calls still arrive (Google-internal network).
+- **Availability**: enforcement happens on Google's edge (LB SLA 99.99%),
+  costs the backend nothing, and per-IP keying means an attack degrades
+  only the attacker — this is what lets the limiter *protect* the 99.99%
+  ingestion target instead of threatening it.
+
+### AWS: API Gateway throttling with isolated budgets
+
+HTTP APIs cannot do per-client throttling natively, so the design isolates
+token buckets per traffic class:
+
+- **Ping routes** get a dedicated budget (`ping_throttling_rate_limit`/
+  `ping_throttling_burst_limit`) — a flood against the dashboard API can
+  never starve ping ingestion, and vice versa.
+- **Everything else** shares the stage default
+  (`api_gateway_throttling_rate_limit`/`_burst_limit`).
+- Throttling is enforced by API Gateway before Lambda is invoked, so
+  floods cost no compute and cannot exhaust Lambda concurrency.
+- **If AWS becomes a primary target**: put CloudFront + WAF (rate-based
+  rules are per-IP) in front of the API for parity with Cloud Armor.
+
+### In-app limiter (defense-in-depth)
+
+The process-local limiter in `middleware.py` remains as a backstop. Its
+per-instance nature is remedied two ways:
+1. The **authoritative** limits live at the edge (above) where global
+   traffic is visible.
+2. Its keying is now correct behind proxies: `TRUSTED_PROXY_HOPS` tells it
+   how many trailing `X-Forwarded-For` entries were appended by trusted
+   infrastructure (2 behind the global LB, 1 for direct Cloud Run, 0 on
+   Lambda where API Gateway supplies the real source IP). Entries earlier
+   in the header are client-supplied and ignored, so spoofing can only
+   diversify an attacker's keys at the in-app layer — the edge layer keys
+   on the true connection IP regardless.
+
 ## Alert Delivery Pipeline
 
 Every alert (late / recovery / escalation) is written as a durable

--- a/infra/aws/api-gateway.tf
+++ b/infra/aws/api-gateway.tf
@@ -35,9 +35,32 @@ resource "aws_apigatewayv2_stage" "main" {
     })
   }
 
+  # Shared token bucket for the management API. HTTP APIs can't do
+  # per-client throttling natively (that needs CloudFront+WAF in front);
+  # what we CAN do is isolate budgets so one traffic class can't starve
+  # another — see the per-route settings below.
   default_route_settings {
     throttling_rate_limit  = var.api_gateway_throttling_rate_limit
     throttling_burst_limit = var.api_gateway_throttling_burst_limit
+  }
+
+  # Ping ingestion gets its own, larger throttle budget on every ping
+  # route. A flood against the dashboard API exhausts only the default
+  # bucket — ping ingestion keeps its full allowance, and vice versa.
+  dynamic "route_settings" {
+    for_each = toset([
+      "GET /ping/{token}",
+      "POST /ping/{token}",
+      "GET /ping/{token}/fail",
+      "POST /ping/{token}/fail",
+      "GET /ping/{token}/start",
+      "POST /ping/{token}/start",
+    ])
+    content {
+      route_key              = route_settings.value
+      throttling_rate_limit  = var.ping_throttling_rate_limit
+      throttling_burst_limit = var.ping_throttling_burst_limit
+    }
   }
 
   tags = {

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -105,3 +105,15 @@ variable "heartbeat_url" {
   type        = string
   default     = ""
 }
+
+variable "ping_throttling_rate_limit" {
+  description = "Dedicated steady-state throttle (req/s) for ping ingestion routes, isolated from the management API budget"
+  type        = number
+  default     = 500
+}
+
+variable "ping_throttling_burst_limit" {
+  description = "Dedicated burst throttle for ping ingestion routes"
+  type        = number
+  default     = 1000
+}

--- a/infra/gcp/cloudrun.tf
+++ b/infra/gcp/cloudrun.tf
@@ -4,6 +4,17 @@ resource "google_cloud_run_service" "pulsechecks_api" {
   location = var.gcp_region
   project  = var.gcp_project_id
 
+  # When edge throttling is on, public traffic MUST come through the
+  # global LB (where Cloud Armor enforces per-IP limits). Without this,
+  # the run.app URL is a direct bypass around the rate limiter.
+  # "internal-and-cloud-load-balancing" still admits Cloud Scheduler's
+  # OIDC calls (they arrive over Google's internal network).
+  metadata {
+    annotations = {
+      "run.googleapis.com/ingress" = var.edge_throttling_enabled ? "internal-and-cloud-load-balancing" : "all"
+    }
+  }
+
   template {
     spec {
       service_account_name = google_service_account.cloudrun_sa.email
@@ -71,6 +82,14 @@ resource "google_cloud_run_service" "pulsechecks_api" {
         env {
           name  = "HEARTBEAT_URL"
           value = var.heartbeat_url
+        }
+
+        # In-app rate limiter keying: how many trailing X-Forwarded-For
+        # entries our infrastructure appends (2 behind the global LB,
+        # 1 when Cloud Run is reached directly)
+        env {
+          name  = "TRUSTED_PROXY_HOPS"
+          value = var.edge_throttling_enabled ? "2" : "1"
         }
 
         # SMTP for email alert channels (optional — email channels are

--- a/infra/gcp/edge_throttling.tf
+++ b/infra/gcp/edge_throttling.tf
@@ -41,6 +41,37 @@ resource "google_compute_security_policy" "api_edge" {
 
   name = "pulsechecks-api-edge-policy-${var.environment}"
 
+  # All rate rules key on client IP (enforce_on_key = "IP").
+  # Without it Cloud Armor defaults to "ALL" — one shared bucket for every
+  # client — so a single flooder would exhaust the budget and legitimate
+  # ping traffic would be the collateral damage. Per-IP keying is what
+  # makes the limiter protect availability instead of threatening it.
+
+  # Stricter per-IP limit for the management API (everything except /ping/
+  # and /health). Dashboards don't need hundreds of requests per minute.
+  rule {
+    priority = 900
+    action   = "throttle"
+
+    match {
+      expr {
+        expression = "!request.path.startsWith('/ping/') && request.path != '/health'"
+      }
+    }
+
+    rate_limit_options {
+      conform_action = "allow"
+      exceed_action  = "deny(429)"
+      enforce_on_key = "IP"
+
+      rate_limit_threshold {
+        count        = var.edge_throttle_api_requests_per_minute
+        interval_sec = 60
+      }
+    }
+  }
+
+  # Per-IP short-window throttle (protects against bursts)
   rule {
     priority = 1000
     action   = "throttle"
@@ -55,6 +86,7 @@ resource "google_compute_security_policy" "api_edge" {
     rate_limit_options {
       conform_action = "allow"
       exceed_action  = "deny(429)"
+      enforce_on_key = "IP"
 
       rate_limit_threshold {
         count        = var.edge_throttle_requests_per_second
@@ -63,9 +95,11 @@ resource "google_compute_security_policy" "api_edge" {
     }
   }
 
+  # Per-IP sustained-rate ban: clients far above the budget for a full
+  # minute get banned outright for a cool-down instead of retrying 429s.
   rule {
     priority = 1010
-    action   = "throttle"
+    action   = "rate_based_ban"
 
     match {
       versioned_expr = "SRC_IPS_V1"
@@ -75,8 +109,10 @@ resource "google_compute_security_policy" "api_edge" {
     }
 
     rate_limit_options {
-      conform_action = "allow"
-      exceed_action  = "deny(429)"
+      conform_action   = "allow"
+      exceed_action    = "deny(429)"
+      enforce_on_key   = "IP"
+      ban_duration_sec = var.edge_throttle_ban_duration_seconds
 
       rate_limit_threshold {
         count        = var.edge_throttle_burst

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -151,3 +151,15 @@ variable "heartbeat_url" {
   type        = string
   default     = ""
 }
+
+variable "edge_throttle_api_requests_per_minute" {
+  description = "Per-IP Cloud Armor limit for management API paths (everything except /ping/ and /health)"
+  type        = number
+  default     = 300
+}
+
+variable "edge_throttle_ban_duration_seconds" {
+  description = "How long Cloud Armor bans an IP that sustains traffic above the burst threshold"
+  type        = number
+  default     = 600
+}


### PR DESCRIPTION
## Summary

The remedy for the per-instance in-app limiter is architectural: **authoritative rate limits must live at the cloud edge, keyed per client IP** — no serverless process can see global traffic. This PR makes each cloud's edge actually enforce that, and fixes three real defects found while doing it.

### GCP (primary) — Cloud Armor on the global HTTPS LB
- **Fixed: rules had no `enforce_on_key`**, so Cloud Armor defaulted to one *global* shared bucket — a single flooder exhausted the whole budget and legitimate pings ate the 429s. Every rule now keys per IP, which is what makes the limiter protect the 99.99% ingestion target instead of threatening it (an attack degrades only the attacker).
- **Fixed: the `run.app` URL bypassed Cloud Armor entirely.** Cloud Run ingress is now `internal-and-cloud-load-balancing` when edge throttling is on; Cloud Scheduler's OIDC calls still arrive over Google's internal network.
- Added a stricter per-IP rule for management-API paths (300/min default — dashboards don't need more) and a `rate_based_ban` rule (10-min ban) for sustained abuse.
- Availability: enforcement runs on Google's edge (LB SLA 99.99%) at zero backend cost.

### AWS — API Gateway with isolated budgets
- **Fixed: one shared stage bucket meant a dashboard flood drained the same budget as ping ingestion.** Ping routes now have a dedicated throttle budget (500 rps / 1000 burst default), isolated from the stage default. Floods are rejected before Lambda is invoked — no compute cost, no concurrency exhaustion.
- HTTP APIs can't do per-client limits natively; documented CloudFront + WAF as the parity step if AWS becomes a primary target.

### In-app limiter (kept as defense-in-depth, keying fixed)
- New `TRUSTED_PROXY_HOPS` setting: keys on the real client IP from the trailing *trusted* `X-Forwarded-For` entries (2 behind the GLB, 1 for direct Cloud Run, 0 on Lambda where API Gateway supplies the true source IP). Previously `request.client.host` behind the LB put **every user in one shared in-app bucket**. Client-supplied XFF prefixes are ignored; short/missing headers fail safe to the socket peer. Wired automatically from Terraform.

### Docs
`docs/operations.md` gains a **Rate Limiting Architecture** section recording the per-cloud design, the invariants (per-IP keying, no bypass paths, budget isolation), and the availability rationale.

## Testing

- Backend: 410 passed, 8 skipped — includes 6 new tests covering XFF keying (spoofed prefixes ignored, GLB/direct/Lambda hop counts, fail-safe fallbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi)_