### PR TITLE
Warm standby: cross-cloud mutual watching, definition sync, shadow alerting, Route53 failover

### DIFF
--- a/backend/app/auth/factory.py
+++ b/backend/app/auth/factory.py
@@ -14,6 +14,16 @@ def create_auth_client() -> AuthInterface:
         ValueError: If cloud_provider is not supported
     """
     settings = get_settings()
+    # AUTH_PROVIDER decouples identity from the hosting cloud so the AWS
+    # warm standby can verify the same Firebase tokens as the GCP primary.
+    provider = (settings.auth_provider or settings.cloud_provider).lower()
+    if provider == "firebase":
+        from .firebase import FirebaseAuth
+        return FirebaseAuth()
+    if provider == "cognito":
+        from .cognito import CognitoAuth
+        return CognitoAuth()
+
     cloud_provider = settings.cloud_provider.lower()
 
     if cloud_provider == "aws":

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,11 @@ class Settings(BaseSettings):
 
     # Auth
     allowed_email_domains: str = ""
+    # Override the auth provider independently of cloud_provider
+    # ("firebase" | "cognito"; empty = derive from cloud_provider).
+    # Used to run Firebase Auth on the AWS warm standby so both clouds
+    # share one identity space (user_ids survive failover).
+    auth_provider: str = ""
 
     # Application
     project_name: str = "pulsechecks"
@@ -41,6 +46,16 @@ class Settings(BaseSettings):
     # behind the global HTTPS LB (GFE appends client-ip, lb-ip). Anything
     # earlier in the header is client-supplied and must not be trusted.
     trusted_proxy_hops: int = 0
+
+    # Warm-standby mode: detect and mirror state, but do NOT deliver
+    # alerts for sync-managed checks (the primary is alerting for them).
+    # Native checks (e.g. sentinel watchers of the other cloud) still
+    # alert normally. Promotion = flip this to false.
+    standby_mode: bool = False
+
+    # Cross-cloud definition sync (standby pulls from primary)
+    sync_token: str = ""          # shared secret; empty disables export/import
+    primary_export_url: str = ""  # e.g. https://api.example.com/internal/export-definitions
 
     # Dead-man's-switch: external heartbeat URL pinged after every
     # successful late-detection run. Point this at an independent

--- a/backend/app/db/dynamodb.py
+++ b/backend/app/db/dynamodb.py
@@ -146,6 +146,28 @@ class DynamoDBClient(DatabaseInterface):
             )
             return response.get("Items", [])
 
+    async def list_all_teams(self) -> List[Team]:
+        """List every team (definition export / standby sync)."""
+        async with self._get_table() as table:
+            response = await table.scan(
+                FilterExpression="SK = :sk",
+                ExpressionAttributeValues={":sk": "METADATA"},
+            )
+            teams = []
+            for item in response.get("Items", []):
+                if "teamId" not in item:
+                    continue
+                teams.append(Team(
+                    team_id=item["teamId"],
+                    name=item["name"],
+                    slug=item.get("slug"),
+                    created_at=item["createdAt"],
+                    created_by=item["createdBy"],
+                    mattermost_webhook_url=item.get("mattermostWebhookUrl"),
+                    mattermost_webhooks=item.get("mattermostWebhooks", []),
+                ))
+            return teams
+
     # Membership operations
     async def add_team_member(self, member: TeamMember) -> None:
         """Add a member to a team."""
@@ -246,6 +268,8 @@ class DynamoDBClient(DatabaseInterface):
                 item["failureThreshold"] = check.failure_threshold
             if check.tags:
                 item["tags"] = check.tags
+            if check.managed_by_sync:
+                item["managedBySync"] = True
 
             # Add to token index
             item["GSI2PK"] = f"TOKEN#{check.token}"
@@ -932,6 +956,7 @@ class DynamoDBClient(DatabaseInterface):
             failure_threshold=convert_to_int(item.get("failureThreshold")) or 1,
             slug=item.get("slug"),
             tags=item.get("tags", []),
+            managed_by_sync=bool(item.get("managedBySync", False)),
         )
 
     async def query_due_http_checks(self, current_time_seconds: int, limit: int = 500) -> List[Check]:

--- a/backend/app/db/firestore.py
+++ b/backend/app/db/firestore.py
@@ -145,6 +145,22 @@ class FirestoreClient(DatabaseInterface):
             mattermost_webhooks=data.get('mattermostWebhooks', []),
         )
 
+    async def list_all_teams(self) -> List[Team]:
+        """List every team (definition export / standby sync)."""
+        teams = []
+        async for doc in self.db.collection('teams').stream():
+            data = doc.to_dict()
+            teams.append(Team(
+                team_id=data['teamId'],
+                name=data['name'],
+                slug=data.get('slug'),
+                created_at=data['createdAt'],
+                created_by=data['createdBy'],
+                mattermost_webhook_url=data.get('mattermostWebhookUrl'),
+                mattermost_webhooks=data.get('mattermostWebhooks', []),
+            ))
+        return teams
+
     async def get_team_by_slug(self, team_slug: str) -> Optional[Team]:
         """Get team by slug."""
         query = self.db.collection('teams').where('slug', '==', team_slug).limit(1)
@@ -346,6 +362,7 @@ class FirestoreClient(DatabaseInterface):
             'expectedString': check.expected_string,
             'failureThreshold': check.failure_threshold,
             'tags': check.tags or [],
+            'managedBySync': check.managed_by_sync,
         }
 
         # Remove None values (but keep slug and other important fields)
@@ -1143,4 +1160,5 @@ class FirestoreClient(DatabaseInterface):
             suppress_duration_minutes=int(data['suppressDurationMinutes']) if data.get('suppressDurationMinutes') else None,
             consecutive_failure_count=int(data.get('consecutiveFailureCount', 0)),
             tags=data.get('tags', []),
+            managed_by_sync=bool(data.get('managedBySync', False)),
         )

--- a/backend/app/db/interface.py
+++ b/backend/app/db/interface.py
@@ -229,6 +229,11 @@ class DatabaseInterface(ABC):
         """Delete a maintenance window."""
         pass
 
+    @abstractmethod
+    async def list_all_teams(self) -> List[Team]:
+        """List every team (definition export / standby sync)."""
+        pass
+
     # Audit log operations
 
     @abstractmethod

--- a/backend/app/handlers.py
+++ b/backend/app/handlers.py
@@ -38,7 +38,15 @@ async def _late_detector_impl(event: Dict[str, Any], context: Any) -> Dict[str, 
     escalations_triggered = 0
     alerts_suppressed = 0
 
+    standby = settings.standby_mode
+
     for check in due_checks:
+        # Warm-standby shadow mode: mirror state transitions but never
+        # deliver alerts for checks synced from the primary — the primary
+        # is alerting for them. Native checks (sentinel watchers of the
+        # other cloud) alert normally. Promotion flips STANDBY_MODE off.
+        shadow = standby and getattr(check, "managed_by_sync", False)
+
         # Check if alerts are currently suppressed
         if _is_suppressed(check, current_time):
             alerts_suppressed += 1
@@ -66,12 +74,13 @@ async def _late_detector_impl(event: Dict[str, Any], context: Any) -> Dict[str, 
 
             # Enqueue durable deliveries and attempt them immediately;
             # failures stay pending and are retried with backoff below.
-            deliveries = await enqueue_check_alerts(db, check, "late", team=team)
-            alerts_queued += len(deliveries)
-            alerts_delivered += sum(1 for d in deliveries if d.status == "delivered")
+            if not shadow:
+                deliveries = await enqueue_check_alerts(db, check, "late", team=team)
+                alerts_queued += len(deliveries)
+                alerts_delivered += sum(1 for d in deliveries if d.status == "delivered")
 
         # Check for escalation (even if check was already late)
-        if _should_escalate(check, current_time):
+        if not shadow and _should_escalate(check, current_time):
             # Trigger escalation
             await db.mark_escalation_triggered(check.team_id, check.check_id, get_iso_timestamp())
 

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -96,6 +96,7 @@ class Check(BaseModel):
     escalation_minutes: Optional[int] = None  # Minutes before escalating
     escalation_alert_channels: list[str] = []  # Alert channels for escalated alerts
     tags: list[str] = []  # Free-form labels for filtering/grouping
+    managed_by_sync: bool = False  # Mirrored from the primary by standby sync
     escalation_mattermost_channels: list[str] = []  # Mattermost channels for escalated alerts (legacy)
     escalation_triggered_at: Optional[str] = None  # When escalation was last triggered
 

--- a/backend/app/routers/internal.py
+++ b/backend/app/routers/internal.py
@@ -121,3 +121,51 @@ async def http_poll(request: Request):
     await _verify_oidc(request)
     await poll_http_checks()
     return {"ok": True}
+
+
+def _verify_sync_token(request: Request) -> None:
+    """Authenticate the cross-cloud sync pull via the shared SYNC_TOKEN.
+
+    Fails closed: if no token is configured on this deployment, the export
+    endpoint does not exist as far as callers are concerned (404-shaped 403).
+    The payload includes check ping tokens and channel configurations, so
+    this must be treated as a credential-grade gate.
+    """
+    from ..config import get_settings
+    from ..utils.token_security import timing_safe_compare
+
+    configured = get_settings().sync_token
+    provided = request.headers.get("X-Sync-Token", "")
+    if not configured or not provided or not timing_safe_compare(provided, configured):
+        logger.warning("Rejected definitions export: missing or invalid sync token")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+
+@router.get("/export-definitions")
+async def export_definitions(request: Request):
+    """Definitions export for the warm standby (teams, members, checks, channels).
+
+    Pulled by the other cloud's sync job. Protected by SYNC_TOKEN.
+    """
+    _verify_sync_token(request)
+
+    from ..standby_sync import build_definitions_export
+    db = create_db_client()
+    payload = await build_definitions_export(db)
+    logger.info("Definitions export served (%d teams)", len(payload.get("teams", [])))
+    return payload
+
+
+@router.post("/standby-sync")
+async def run_standby_sync(request: Request):
+    """Trigger a sync pull on the standby (scheduler-invoked, OIDC on GCP,
+    or SYNC_TOKEN for cross-cloud/manual invocation)."""
+    if request.headers.get("X-Sync-Token"):
+        _verify_sync_token(request)
+    else:
+        await _verify_oidc(request)
+
+    from ..standby_sync import pull_definitions_from_primary
+    db = create_db_client()
+    counts = await pull_definitions_from_primary(db)
+    return {"ok": True, "synced": counts}

--- a/backend/app/routers/ping.py
+++ b/backend/app/routers/ping.py
@@ -163,7 +163,9 @@ async def _record_ping_internal(
         # Enqueue-only (attempt_now=False): the ping request must never
         # block on outbound notification calls. The late-detection
         # scheduler drains the queue within ~2 minutes.
-        if was_late and ping_type == PingType.SUCCESS and check.alert_channels:
+        settings = get_settings()
+        shadow = settings.standby_mode and getattr(check, "managed_by_sync", False)
+        if was_late and ping_type == PingType.SUCCESS and check.alert_channels and not shadow:
             try:
                 from ..alert_dispatch import enqueue_check_alerts
                 await enqueue_check_alerts(check=check, db=db, alert_type="recovery", attempt_now=False)

--- a/backend/app/standby_sync.py
+++ b/backend/app/standby_sync.py
@@ -1,0 +1,114 @@
+"""Cross-cloud definition sync for the warm standby.
+
+The standby (AWS) periodically pulls *definitions* — teams, members, checks
+(including ping tokens, so customer URLs survive failover), and alert
+channels — from the primary (GCP) and mirrors them into its own database.
+Ping history is deliberately not synced: it is ephemeral (90-day TTL) and
+irrelevant to taking over ingestion + alerting.
+
+Security: the export endpoint is protected by SYNC_TOKEN, a shared secret
+compared in constant time. The payload includes check tokens and channel
+configurations (webhook URLs, SMTP recipients), so treat the token with
+the same care as a database credential.
+"""
+import asyncio
+from typing import Any, Dict
+
+import httpx
+
+from .config import get_settings
+from .models import AlertChannel, Check, Team, TeamMember
+from .logging_config import get_logger, log_business_event
+
+logger = get_logger(__name__)
+
+SYNC_HTTP_TIMEOUT = 30.0
+
+
+async def build_definitions_export(db) -> Dict[str, Any]:
+    """Collect every team's definitions into a portable payload."""
+    teams = await db.list_all_teams()
+    payload = {"version": 1, "teams": []}
+
+    for team in teams:
+        members = await db.list_team_members(team.team_id)
+        checks = await db.list_team_checks(team.team_id)
+        channels = await db.list_alert_channels(team.team_id)
+        payload["teams"].append({
+            "team": team.model_dump(),
+            "members": [m.model_dump() for m in members],
+            "checks": [c.model_dump() for c in checks],
+            "channels": [c.model_dump() for c in channels],
+        })
+
+    return payload
+
+
+async def apply_definitions(db, payload: Dict[str, Any]) -> Dict[str, int]:
+    """Mirror an export payload into the local database (upsert semantics).
+
+    Synced checks are stamped managed_by_sync=True so the late detector's
+    shadow mode knows not to alert for them while STANDBY_MODE is on.
+    Entities deleted on the primary linger here until promotion cleanup —
+    acceptable for a standby whose job is to not miss anything.
+    """
+    counts = {"teams": 0, "members": 0, "checks": 0, "channels": 0}
+
+    for entry in payload.get("teams", []):
+        team = Team(**entry["team"])
+        await db.create_team(team)
+        counts["teams"] += 1
+
+        for member_data in entry.get("members", []):
+            await db.add_team_member(TeamMember(**member_data))
+            counts["members"] += 1
+
+        for check_data in entry.get("checks", []):
+            check = Check(**check_data)
+            check.managed_by_sync = True
+            await db.create_check(check)
+            counts["checks"] += 1
+
+        for channel_data in entry.get("channels", []):
+            await db.create_alert_channel(AlertChannel(**channel_data))
+            counts["channels"] += 1
+
+    return counts
+
+
+async def pull_definitions_from_primary(db) -> Dict[str, int]:
+    """Fetch the primary's export and mirror it locally."""
+    settings = get_settings()
+    if not settings.primary_export_url or not settings.sync_token:
+        raise RuntimeError(
+            "Standby sync requires PRIMARY_EXPORT_URL and SYNC_TOKEN to be set"
+        )
+
+    async with httpx.AsyncClient(timeout=SYNC_HTTP_TIMEOUT) as client:
+        response = await client.get(
+            settings.primary_export_url,
+            headers={"X-Sync-Token": settings.sync_token},
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+    counts = await apply_definitions(db, payload)
+    log_business_event("standby_sync_completed", **counts)
+    logger.info(f"Standby sync completed: {counts}")
+    return counts
+
+
+def standby_sync_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Lambda entry point (EventBridge scheduled) for the standby sync pull."""
+    from .db import create_db_client
+
+    async def _run():
+        db = create_db_client()
+        return await pull_definitions_from_primary(db)
+
+    try:
+        counts = asyncio.run(_run())
+        return {"statusCode": 200, "body": str(counts)}
+    except Exception as e:
+        logger.error(f"Standby sync failed: {e}")
+        return {"statusCode": 500, "body": str(e)}

--- a/backend/tests/test_standby_sync.py
+++ b/backend/tests/test_standby_sync.py
@@ -1,0 +1,209 @@
+"""Tests for warm-standby sync, shadow mode, and auth provider override."""
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.standby_sync import apply_definitions, build_definitions_export
+from app.models import AlertChannel, AlertChannelType, Check, CheckStatus, Role, Team, TeamMember
+
+client = TestClient(app)
+
+
+def _team():
+    return Team(team_id="team-1", name="SRE", slug="sre",
+                created_at="2026-01-01T00:00:00Z", created_by="user-1")
+
+
+def _check(check_id="check-1", managed=False):
+    return Check(
+        check_id=check_id, team_id="team-1", name="Nightly Backup",
+        token="tok-123", period_seconds=3600, grace_seconds=300,
+        status=CheckStatus.UP, created_at="2026-01-01T00:00:00Z",
+        alert_channels=["chan-1"], managed_by_sync=managed,
+    )
+
+
+def _channel():
+    return AlertChannel(
+        channel_id="chan-1", team_id="team-1", name="oncall",
+        display_name="On-call", type=AlertChannelType.MATTERMOST,
+        configuration={"webhook_url": "https://chat.example.com/hooks/x"},
+        shared=False, created_at="2026-01-01T00:00:00Z", created_by="user-1",
+    )
+
+
+class TestAuthProviderOverride:
+    def test_firebase_on_aws(self):
+        from app.auth.factory import create_auth_client
+        settings = MagicMock()
+        settings.auth_provider = "firebase"
+        settings.cloud_provider = "aws"
+        settings.firebase_project_id = "proj"
+        settings.gcp_project = ""
+        with patch("app.auth.factory.get_settings", return_value=settings), \
+             patch("app.auth.firebase.get_settings", return_value=settings):
+            auth = create_auth_client()
+        assert type(auth).__name__ == "FirebaseAuth"
+
+    def test_default_derives_from_cloud(self):
+        from app.auth.factory import create_auth_client
+        settings = MagicMock()
+        settings.auth_provider = ""
+        settings.cloud_provider = "gcp"
+        settings.firebase_project_id = "proj"
+        settings.gcp_project = "proj"
+        with patch("app.auth.factory.get_settings", return_value=settings), \
+             patch("app.auth.firebase.get_settings", return_value=settings):
+            auth = create_auth_client()
+        assert type(auth).__name__ == "FirebaseAuth"
+
+
+class TestExportImport:
+    @pytest.mark.asyncio
+    async def test_export_collects_all_definitions(self):
+        db = AsyncMock()
+        db.list_all_teams.return_value = [_team()]
+        db.list_team_members.return_value = [TeamMember(
+            team_id="team-1", user_id="user-1", role=Role.ADMIN,
+            joined_at="2026-01-01T00:00:00Z")]
+        db.list_team_checks.return_value = [_check()]
+        db.list_alert_channels.return_value = [_channel()]
+
+        payload = await build_definitions_export(db)
+
+        assert payload["version"] == 1
+        assert len(payload["teams"]) == 1
+        entry = payload["teams"][0]
+        assert entry["team"]["team_id"] == "team-1"
+        assert entry["checks"][0]["token"] == "tok-123"  # tokens must survive failover
+        assert entry["channels"][0]["configuration"]["webhook_url"].startswith("https://")
+        # Payload must be JSON-serializable end to end
+        json.dumps(payload)
+
+    @pytest.mark.asyncio
+    async def test_apply_upserts_and_stamps_sync_flag(self):
+        db = AsyncMock()
+        source = AsyncMock()
+        source.list_all_teams.return_value = [_team()]
+        source.list_team_members.return_value = []
+        source.list_team_checks.return_value = [_check()]
+        source.list_alert_channels.return_value = [_channel()]
+        payload = await build_definitions_export(source)
+
+        counts = await apply_definitions(db, payload)
+
+        assert counts == {"teams": 1, "members": 0, "checks": 1, "channels": 1}
+        imported_check = db.create_check.call_args[0][0]
+        assert imported_check.managed_by_sync is True
+        assert imported_check.token == "tok-123"
+
+
+class TestExportEndpointAuth:
+    def _settings(self, token):
+        # Patched app-wide, so every field the middleware touches needs a
+        # real value (MagicMock attributes break comparisons).
+        settings = MagicMock()
+        settings.sync_token = token
+        settings.trusted_proxy_hops = 0
+        settings.standby_mode = False
+        return settings
+
+    def test_missing_token_rejected(self):
+        with patch("app.config.get_settings", return_value=self._settings("secret")):
+            response = client.get("/internal/export-definitions")
+        assert response.status_code == 403
+
+    def test_wrong_token_rejected(self):
+        with patch("app.config.get_settings", return_value=self._settings("secret")):
+            response = client.get(
+                "/internal/export-definitions", headers={"X-Sync-Token": "wrong"}
+            )
+        assert response.status_code == 403
+
+    def test_unconfigured_token_rejects_everything(self):
+        with patch("app.config.get_settings", return_value=self._settings("")):
+            response = client.get(
+                "/internal/export-definitions", headers={"X-Sync-Token": "anything"}
+            )
+        assert response.status_code == 403
+
+    def test_valid_token_serves_export(self):
+        db = AsyncMock()
+        db.list_all_teams.return_value = []
+        with patch("app.config.get_settings", return_value=self._settings("secret")), \
+             patch("app.routers.internal.create_db_client", return_value=db):
+            response = client.get(
+                "/internal/export-definitions", headers={"X-Sync-Token": "secret"}
+            )
+        assert response.status_code == 200
+        assert response.json() == {"version": 1, "teams": []}
+
+
+class TestShadowMode:
+    @pytest.mark.asyncio
+    async def test_standby_skips_alerts_for_synced_checks(self):
+        from app.handlers import _late_detector_impl
+
+        db = AsyncMock()
+        db.query_due_checks.return_value = [_check(managed=True)]
+        db.update_check_to_late.return_value = True
+        db.query_due_alert_deliveries.return_value = []
+
+        settings = MagicMock()
+        settings.standby_mode = True
+        settings.heartbeat_url = ""
+
+        with patch("app.handlers.create_db_client", return_value=db), \
+             patch("app.handlers.get_settings", return_value=settings), \
+             patch("app.handlers.get_metrics_client"), \
+             patch("app.handlers.enqueue_check_alerts", new=AsyncMock()) as mock_enqueue:
+            result = await _late_detector_impl({}, None)
+
+        mock_enqueue.assert_not_called()  # shadow: detect, never alert
+        body = json.loads(result["body"])
+        assert body["checksProcessed"] == 1
+        assert body["channelAlertsQueued"] == 0
+
+    @pytest.mark.asyncio
+    async def test_standby_still_alerts_for_native_checks(self):
+        from app.handlers import _late_detector_impl
+
+        db = AsyncMock()
+        db.query_due_checks.return_value = [_check(managed=False)]  # sentinel watcher
+        db.update_check_to_late.return_value = True
+        db.query_due_alert_deliveries.return_value = []
+
+        settings = MagicMock()
+        settings.standby_mode = True
+        settings.heartbeat_url = ""
+
+        with patch("app.handlers.create_db_client", return_value=db), \
+             patch("app.handlers.get_settings", return_value=settings), \
+             patch("app.handlers.get_metrics_client"), \
+             patch("app.handlers.enqueue_check_alerts", new=AsyncMock(return_value=[])) as mock_enqueue:
+            await _late_detector_impl({}, None)
+
+        mock_enqueue.assert_called_once()  # native checks alert even in standby
+
+    @pytest.mark.asyncio
+    async def test_promotion_restores_alerting(self):
+        from app.handlers import _late_detector_impl
+
+        db = AsyncMock()
+        db.query_due_checks.return_value = [_check(managed=True)]
+        db.update_check_to_late.return_value = True
+        db.query_due_alert_deliveries.return_value = []
+
+        settings = MagicMock()
+        settings.standby_mode = False  # promoted
+        settings.heartbeat_url = ""
+
+        with patch("app.handlers.create_db_client", return_value=db), \
+             patch("app.handlers.get_settings", return_value=settings), \
+             patch("app.handlers.get_metrics_client"), \
+             patch("app.handlers.enqueue_check_alerts", new=AsyncMock(return_value=[])) as mock_enqueue:
+            await _late_detector_impl({}, None)
+
+        mock_enqueue.assert_called_once()  # synced checks alert after promotion

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -51,6 +51,76 @@ curl -X POST https://api.pulsechecks.example.com/ping/test-token \
   -d "Health check test"
 ```
 
+## Warm Standby & Mutual Watching (Who Watches the Watchers)
+
+Two independent deployments watch **each other**, dogfooding PulseChecks
+itself. GCP is the primary; AWS runs as a warm standby that can take over
+ingestion + alerting.
+
+### Mutual watching (sentinel checks — set up once)
+
+On the **AWS** deployment (watches GCP):
+1. Create an HTTP check on `https://api.<domain>/health` — detects GCP API down.
+2. Create a heartbeat check; set the GCP primary's `HEARTBEAT_URL` to its
+   ping URL — detects GCP's detection loop silently stopping.
+3. Attach real alert channels (SNS email / Mattermost) to both.
+
+On the **GCP** deployment (watches AWS): mirror image — HTTP check on the
+AWS API's `/health`, and AWS's `HEARTBEAT_URL` pings a GCP-hosted check.
+
+Accepted residual risk (explicit decision): a *simultaneous* AWS+GCP
+failure silences monitoring. No third-party backstop is configured.
+
+### Standby configuration (AWS tfvars)
+
+```hcl
+auth_provider       = "firebase"        # one identity space with the primary
+firebase_project_id = "<gcp-project>"
+standby_mode        = true              # shadow alerting for synced checks
+sync_token          = "<long random>"   # same value as GCP's sync_token
+primary_export_url  = "https://api.<domain>/internal/export-definitions"
+
+enable_cross_cloud_failover = true
+primary_api_fqdn            = "<GCP LB hostname or api domain>"
+gcp_primary_api_ip          = "<terraform output from infra/gcp>"
+```
+
+On GCP, set the matching `sync_token`. The sync payload contains **check
+ping tokens and channel configurations** — treat `sync_token` as a
+database credential.
+
+### How it behaves day-to-day
+
+- Every 5 min the standby pulls team/member/check/channel definitions
+  (`standby-sync` Lambda) and mirrors them, stamped `managed_by_sync`.
+- The standby's late detector runs in **shadow mode**: it tracks state for
+  synced checks but never alerts for them (the primary is alerting).
+  Its own sentinel checks alert normally.
+- Route53 health-checks the primary's `/health` every 30s; on 3
+  consecutive failures, `api.<domain>` fails over to the AWS API Gateway
+  (TTL 60s). Customer pings start landing on the standby automatically —
+  tokens match because they were synced.
+
+### Promotion runbook (manual, by design)
+
+DNS failover for *ingestion* is automatic. Enabling the standby's
+*alerting* is a human decision — automatic promotion under a network
+partition would produce split-brain double alerting.
+
+1. Confirm the primary is really down (not just the health check):
+   Cloud Run console, Cloud Status Dashboard, `curl` the run.app URL.
+2. Verify DNS has failed over: `dig api.<domain>` returns the AWS answer.
+3. Promote: set `standby_mode = false` in the AWS tfvars and apply
+   (or update the two Lambdas' `STANDBY_MODE` env var to `false` directly
+   for speed) — synced checks now alert.
+4. Announce; monitor the AWS deployment's Alert History for deliveries.
+
+**Fail-back** when GCP recovers: confirm Route53 flipped back to primary,
+then restore `standby_mode = true` on AWS. The next sync pull re-mirrors
+anything that changed during the outage window. Note: pings ingested on
+AWS during failover stay on AWS (history diverges for that window —
+accepted; definitions re-converge automatically).
+
 ## Rate Limiting Architecture
 
 Rate limiting is enforced **at the cloud edge, per client IP** — never as a

--- a/infra/aws/dns.tf
+++ b/infra/aws/dns.tf
@@ -76,3 +76,63 @@ module "acm_validation_records" {
   distinct_domain_names                     = module.acm_certificate.distinct_domain_names
   acm_certificate_domain_validation_options = module.acm_certificate.acm_certificate_domain_validation_options
 }
+
+
+# ─── Cross-cloud failover for the API domain ────────────────────────────────
+# Route53 health-checks the GCP primary; while healthy, api.<domain> resolves
+# to the GCP load balancer. When the health check fails, DNS fails over to
+# this cloud's API Gateway. Ingestion DNS failover is automatic; alert
+# *promotion* (STANDBY_MODE=false) stays a manual runbook step by design.
+
+resource "aws_route53_health_check" "gcp_primary" {
+  count = var.enable_cross_cloud_failover ? 1 : 0
+
+  fqdn              = var.primary_api_fqdn
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/health"
+  failure_threshold = 3
+  request_interval  = 30
+
+  tags = {
+    Name = "${var.project_name}-gcp-primary-health"
+  }
+}
+
+resource "aws_route53_record" "api_failover_primary" {
+  count    = var.enable_cross_cloud_failover ? 1 : 0
+  provider = aws.route53
+
+  zone_id        = data.aws_route53_zone.main.zone_id
+  name           = "api.${var.domain_name}"
+  type           = "A"
+  ttl            = 60
+  records        = [var.gcp_primary_api_ip]
+  set_identifier = "gcp-primary"
+
+  failover_routing_policy {
+    type = "PRIMARY"
+  }
+
+  health_check_id = aws_route53_health_check.gcp_primary[0].id
+}
+
+resource "aws_route53_record" "api_failover_secondary" {
+  count    = var.enable_cross_cloud_failover ? 1 : 0
+  provider = aws.route53
+
+  zone_id        = data.aws_route53_zone.main.zone_id
+  name           = "api.${var.domain_name}"
+  type           = "A"
+  set_identifier = "aws-standby"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.api.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.api.domain_name_configuration[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+
+  failover_routing_policy {
+    type = "SECONDARY"
+  }
+}

--- a/infra/aws/eventbridge.tf
+++ b/infra/aws/eventbridge.tf
@@ -24,3 +24,31 @@ resource "aws_lambda_permission" "allow_eventbridge" {
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.late_detector.arn
 }
+
+
+# Standby sync every 5 minutes (standby mode only)
+resource "aws_cloudwatch_event_rule" "standby_sync" {
+  count = var.standby_mode ? 1 : 0
+
+  name                = "${var.project_name}-standby-sync-${var.environment}"
+  description         = "Pull definitions from the primary cloud"
+  schedule_expression = "rate(5 minutes)"
+}
+
+resource "aws_cloudwatch_event_target" "standby_sync" {
+  count = var.standby_mode ? 1 : 0
+
+  rule      = aws_cloudwatch_event_rule.standby_sync[0].name
+  target_id = "StandbySyncLambda"
+  arn       = aws_lambda_function.standby_sync[0].arn
+}
+
+resource "aws_lambda_permission" "standby_sync_eventbridge" {
+  count = var.standby_mode ? 1 : 0
+
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.standby_sync[0].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.standby_sync[0].arn
+}

--- a/infra/aws/lambdas.tf
+++ b/infra/aws/lambdas.tf
@@ -144,6 +144,11 @@ resource "aws_lambda_function" "api" {
       SMTP_USERNAME         = var.smtp_username
       SMTP_PASSWORD         = var.smtp_password
       SMTP_FROM             = var.smtp_from
+      AUTH_PROVIDER         = var.auth_provider
+      FIREBASE_PROJECT_ID   = var.firebase_project_id
+      STANDBY_MODE          = var.standby_mode ? "true" : "false"
+      SYNC_TOKEN            = var.sync_token
+      PRIMARY_EXPORT_URL    = var.primary_export_url
     }
   }
 
@@ -171,11 +176,45 @@ resource "aws_lambda_function" "late_detector" {
     variables = {
       DYNAMODB_TABLE = aws_dynamodb_table.pulsechecks.name
       HEARTBEAT_URL  = var.heartbeat_url
+      STANDBY_MODE   = var.standby_mode ? "true" : "false"
       SMTP_HOST      = var.smtp_host
       SMTP_PORT      = var.smtp_port
       SMTP_USERNAME  = var.smtp_username
       SMTP_PASSWORD  = var.smtp_password
       SMTP_FROM      = var.smtp_from
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      filename,
+      source_code_hash
+    ]
+  }
+}
+
+
+# Standby definition-sync Lambda: pulls teams/checks/channels from the
+# primary cloud every few minutes so this deployment can take over
+# ingestion + alerting on promotion. Only created in standby mode.
+resource "aws_lambda_function" "standby_sync" {
+  count = var.standby_mode ? 1 : 0
+
+  function_name = "${var.project_name}-standby-sync-${var.environment}"
+  role          = aws_iam_role.lambda_exec.arn
+  handler       = "app.standby_sync.standby_sync_handler"
+  runtime       = "python3.13"
+  timeout       = 120
+  memory_size   = 512
+
+  filename         = data.archive_file.lambda_placeholder.output_path
+  source_code_hash = data.archive_file.lambda_placeholder.output_base64sha256
+
+  environment {
+    variables = {
+      DYNAMODB_TABLE     = aws_dynamodb_table.pulsechecks.name
+      SYNC_TOKEN         = var.sync_token
+      PRIMARY_EXPORT_URL = var.primary_export_url
     }
   }
 

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -117,3 +117,54 @@ variable "ping_throttling_burst_limit" {
   type        = number
   default     = 1000
 }
+
+# ─── Warm standby / cross-cloud failover ────────────────────────────────────
+
+variable "auth_provider" {
+  description = "Auth provider override ('firebase' to share identity space with the GCP primary; empty = Cognito)"
+  type        = string
+  default     = ""
+}
+
+variable "firebase_project_id" {
+  description = "Firebase project ID (required when auth_provider = 'firebase')"
+  type        = string
+  default     = ""
+}
+
+variable "standby_mode" {
+  description = "Run this deployment as a warm standby: mirror definitions from the primary, detect but do not alert for synced checks"
+  type        = bool
+  default     = false
+}
+
+variable "sync_token" {
+  description = "Shared secret authenticating the cross-cloud definitions sync (credential-grade: the payload includes check tokens)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "primary_export_url" {
+  description = "The primary's export endpoint, e.g. https://api.example.com/internal/export-definitions"
+  type        = string
+  default     = ""
+}
+
+variable "enable_cross_cloud_failover" {
+  description = "Create Route53 health-checked failover records for api.<domain> (GCP primary -> this cloud's API Gateway)"
+  type        = bool
+  default     = false
+}
+
+variable "primary_api_fqdn" {
+  description = "FQDN Route53 health-checks on the GCP primary (usually api.<domain>... use the LB hostname to avoid checking through the failover record itself)"
+  type        = string
+  default     = ""
+}
+
+variable "gcp_primary_api_ip" {
+  description = "Static global IP of the GCP edge load balancer (terraform output from infra/gcp)"
+  type        = string
+  default     = ""
+}

--- a/infra/gcp/cloudrun.tf
+++ b/infra/gcp/cloudrun.tf
@@ -84,6 +84,13 @@ resource "google_cloud_run_service" "pulsechecks_api" {
           value = var.heartbeat_url
         }
 
+        # Cross-cloud definitions export for the AWS warm standby
+        # (endpoint stays 403 until this is set)
+        env {
+          name  = "SYNC_TOKEN"
+          value = var.sync_token
+        }
+
         # In-app rate limiter keying: how many trailing X-Forwarded-For
         # entries our infrastructure appends (2 behind the global LB,
         # 1 when Cloud Run is reached directly)

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -163,3 +163,10 @@ variable "edge_throttle_ban_duration_seconds" {
   type        = number
   default     = 600
 }
+
+variable "sync_token" {
+  description = "Shared secret authenticating the cross-cloud definitions export (credential-grade: the payload includes check tokens)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

Implements the agreed dual-cloud plan (warm standby / Firebase-everywhere / manual promotion / no third-party backstop):

**Who watches the watchers — mutual watching.** Each cloud runs sentinel checks on the other: an HTTP check on the peer's `/health` plus a heartbeat check the peer's late detector pings via `HEARTBEAT_URL`. Either cloud independently alerts when the other goes dark. Residual risk (accepted by decision): simultaneous dual-cloud failure.

**Warm standby (AWS mirrors GCP):**
- **One identity space**: new `AUTH_PROVIDER` override runs Firebase Auth verification on Lambda (pure PyJWT + Google JWKS — zero new dependencies), so user IDs and team memberships survive failover intact.
- **Definitions sync**: `/internal/export-definitions` on the primary — protected by `SYNC_TOKEN` (constant-time compare, fails closed when unset; the payload carries check ping tokens so customer URLs keep working after failover, making the token credential-grade). A `standby-sync` Lambda pulls every 5 minutes and mirrors teams/members/checks/channels into DynamoDB, stamped `managed_by_sync`. Ping history deliberately doesn't sync (ephemeral, 90-day TTL).
- **Shadow mode** (`STANDBY_MODE`): the standby's late detector and recovery path track state for synced checks but never deliver alerts for them — the primary is alerting. Native sentinel checks alert normally. Promotion = flip the flag.
- **Route53 health-checked failover**: `api.<domain>` PRIMARY → GCP LB IP, SECONDARY → AWS API Gateway (60s TTL, 3×30s health checks on `/health`). Ingestion fails over automatically; **alerting promotion stays manual by design** — automatic promotion under a network partition is exactly how you get split-brain double alerting.

**Runbook**: `docs/operations.md` gains "Warm Standby & Mutual Watching" — sentinel setup, standby tfvars, day-to-day behavior, promotion checklist, and fail-back procedure.

## Testing

- Backend: 421 passed, 8 skipped — 11 new tests covering the auth override, export/import round-trip (tokens preserved, sync flag stamped, JSON-serializable), export endpoint auth (fails closed unset/missing/wrong token), and shadow mode (synced checks silent, native checks alert, promotion restores alerting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi)_