### PR TITLE
Add local mock-backend sandbox for frontend UX design work

### DIFF
--- a/frontend/.env.mock
+++ b/frontend/.env.mock
@@ -1,0 +1,7 @@
+# Loaded automatically by `vite --mode mock` (npm run dev:mock).
+# Points the app at itself — the mock API middleware runs on the same
+# origin/port as the Vite dev server, so no separate process or CORS setup
+# is needed.
+VITE_MOCK=true
+VITE_API_URL=http://localhost:3000
+VITE_CLOUD_PROVIDER=aws

--- a/frontend/mock/README.md
+++ b/frontend/mock/README.md
@@ -1,0 +1,60 @@
+# Design/UX sandbox mode
+
+Runs the real frontend against a fake in-memory backend, with no cloud
+project, no OAuth, and no backend deployment required. Built for pairing
+with a designer on UX — one command, one URL, every screen reachable.
+
+## Run it
+
+```bash
+cd frontend
+npm install   # first time only
+npm run dev:mock
+```
+
+Open **http://localhost:3000**, click **"Continue with demo data"** on the
+login screen. That's it — no credentials, no `.env` setup beyond what's
+already checked in (`.env.mock`).
+
+## What you get
+
+A backend implemented as a Vite dev-server middleware (`mock/server.js`),
+serving realistic, deliberately varied fixture data (`mock/data.js`) so
+every state the UI can be in is reachable without hunting for it:
+
+- Two teams (admin on one, member on the other)
+- Checks in every status: **up**, **late**, **pending** (never pinged),
+  **paused**, plus one **late check with zero alert channels** (the amber
+  "alerts disabled" warning) and one currently **suppressed** check
+- All alert channel types (Mattermost, webhook, email, Telegram, a shared
+  channel), and alert delivery history in every state — delivered,
+  retrying, and dead-lettered/failed
+- 35 pings on one check so "Load more" has something to do
+- Audit log, maintenance windows (past/active/future), reports,
+  API tokens, a pending member invitation
+
+Everything is interactive and stateful for the session: pause a check,
+create a channel, invite a member — it sticks until you restart the dev
+server. Nothing is persisted to disk and nothing leaves your machine.
+
+## How it works
+
+`vite --mode mock` loads `.env.mock` (`VITE_MOCK=true`,
+`VITE_API_URL=http://localhost:3000`) and `vite.config.js` conditionally
+adds the mock middleware, so the frontend and fake API share one origin —
+no CORS, no second process to manage. `LoginPage` shows a demo-login
+button only when `VITE_MOCK=true`; it writes a fake token straight to
+`localStorage` and skips real OAuth entirely. The mock server accepts any
+`Authorization` header without checking it.
+
+None of this ships in `npm run build` / `npm run build:aws` /
+`npm run build:gcp` — the plugin only loads in `mode === 'mock'`, and the
+demo button only renders when `VITE_MOCK === 'true'`, which is never set
+in a real build.
+
+## Editing the fixtures
+
+Everything lives in `mock/data.js` as one plain object (`state`) grouped
+by team ID. Add a check, change a status, add more pings — no schema,
+just edit and refresh. `mock/server.js` is a small hand-rolled router
+(no framework) implementing every endpoint `src/lib/api.js` calls.

--- a/frontend/mock/data.js
+++ b/frontend/mock/data.js
@@ -1,0 +1,411 @@
+// Seed data for the local mock backend (design/UX sandbox only).
+// Deliberately covers every status/edge case the UI needs to render:
+// late checks, zero-channel checks, suppressed checks, pending checks,
+// retrying/failed alert deliveries, long ping history, etc.
+
+const HOUR = 3600
+const now = () => Math.floor(Date.now() / 1000)
+const iso = (secondsAgo = 0) => new Date((now() - secondsAgo) * 1000).toISOString()
+const isoFuture = (secondsAhead = 0) => new Date((now() + secondsAhead) * 1000).toISOString()
+
+export const CURRENT_USER = {
+  userId: 'user-demo-1',
+  email: 'jordan@example.com',
+  name: 'Jordan Alvarez',
+  createdAt: iso(60 * 86400),
+  lastLoginAt: iso(60),
+}
+
+const OTHER_USERS = [
+  { userId: 'user-demo-2', email: 'priya@example.com', name: 'Priya Nandakumar' },
+  { userId: 'user-demo-3', email: 'marcus@example.com', name: 'Marcus Webb' },
+  { userId: 'user-demo-4', email: 'sam@example.com', name: 'Sam Okafor' },
+]
+
+export const state = {
+  teams: [
+    { teamId: 'team-sre', name: 'Platform SRE', slug: 'platform-sre', createdAt: iso(200 * 86400), createdBy: CURRENT_USER.userId },
+    { teamId: 'team-data', name: 'Data Engineering', slug: 'data-engineering', createdAt: iso(120 * 86400), createdBy: 'user-demo-2' },
+  ],
+
+  // teamId -> role for the current user
+  membership: {
+    'team-sre': 'admin',
+    'team-data': 'member',
+  },
+
+  members: {
+    'team-sre': [
+      { userId: CURRENT_USER.userId, email: CURRENT_USER.email, name: CURRENT_USER.name, role: 'admin', joinedAt: iso(200 * 86400), status: 'active' },
+      { userId: 'user-demo-2', email: 'priya@example.com', name: 'Priya Nandakumar', role: 'admin', joinedAt: iso(190 * 86400), status: 'active' },
+      { userId: 'user-demo-3', email: 'marcus@example.com', name: 'Marcus Webb', role: 'member', joinedAt: iso(90 * 86400), status: 'active' },
+      { userId: null, email: 'new-hire@example.com', name: 'Pending User', role: 'member', joinedAt: iso(2 * 86400), status: 'pending' },
+    ],
+    'team-data': [
+      { userId: 'user-demo-2', email: 'priya@example.com', name: 'Priya Nandakumar', role: 'admin', joinedAt: iso(120 * 86400), status: 'active' },
+      { userId: CURRENT_USER.userId, email: CURRENT_USER.email, name: CURRENT_USER.name, role: 'member', joinedAt: iso(45 * 86400), status: 'active' },
+      { userId: 'user-demo-4', email: 'sam@example.com', name: 'Sam Okafor', role: 'member', joinedAt: iso(45 * 86400), status: 'active' },
+    ],
+  },
+
+  channels: {
+    'team-sre': [
+      {
+        channelId: 'chan-mattermost-1', teamId: 'team-sre', name: 'platform-oncall',
+        displayName: 'Platform Oncall (Mattermost)', type: 'mattermost',
+        configuration: { webhook_url: 'https://chat.example.com/hooks/abc123' },
+        shared: false, createdAt: iso(180 * 86400), createdBy: CURRENT_USER.userId,
+      },
+      {
+        channelId: 'chan-webhook-1', teamId: 'team-sre', name: 'pagerduty-bridge',
+        displayName: 'PagerDuty Bridge', type: 'webhook',
+        configuration: { webhook_url: 'https://events.pagerduty.com/integration/xyz/enqueue' },
+        shared: false, createdAt: iso(150 * 86400), createdBy: 'user-demo-2',
+      },
+      {
+        channelId: 'chan-email-1', teamId: 'team-sre', name: 'sre-distro',
+        displayName: 'SRE Distro (Email)', type: 'email',
+        configuration: { recipients: ['sre-oncall@example.com', 'jordan@example.com'] },
+        shared: false, createdAt: iso(100 * 86400), createdBy: CURRENT_USER.userId,
+      },
+      {
+        channelId: 'chan-telegram-1', teamId: 'team-sre', name: 'mobile-alerts',
+        displayName: 'Mobile Alerts', type: 'telegram',
+        configuration: { bot_token: '123456789:AAExampleBotTokenNotReal', chat_id: '-1001234567890' },
+        shared: false, createdAt: iso(60 * 86400), createdBy: 'user-demo-3',
+      },
+      {
+        channelId: 'chan-shared-1', teamId: 'team-sre', name: 'company-incidents',
+        displayName: 'Company-wide Incidents', type: 'mattermost',
+        configuration: { webhook_url: 'https://chat.example.com/hooks/shared456' },
+        shared: true, createdAt: iso(170 * 86400), createdBy: CURRENT_USER.userId,
+      },
+    ],
+    'team-data': [
+      {
+        channelId: 'chan-data-webhook', teamId: 'team-data', name: 'data-eng-webhook',
+        displayName: 'Data Eng Webhook', type: 'webhook',
+        configuration: { webhook_url: 'https://hooks.example.com/data-eng' },
+        shared: false, createdAt: iso(90 * 86400), createdBy: 'user-demo-2',
+      },
+    ],
+  },
+
+  checks: {
+    'team-sre': [
+      {
+        checkId: 'check-1', teamId: 'team-sre', name: 'nightly-db-backup', slug: 'nightly-db-backup',
+        token: 'tok_demo_nightlydbbackup01', status: 'up', type: 'cron', schedule: '0 2 * * *',
+        periodSeconds: null, graceSeconds: 3600,
+        lastPingAt: iso(6 * HOUR), nextDueAt: String(now() + 18 * HOUR), alertAfterAt: String(now() + 19 * HOUR), lastAlertAt: null,
+        createdAt: iso(180 * 86400),
+        alertChannels: ['chan-mattermost-1', 'chan-email-1'],
+        tags: ['prod', 'db'],
+        escalationMinutes: 30, escalationAlertChannels: ['chan-webhook-1'], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+      {
+        checkId: 'check-2', teamId: 'team-sre', name: 'api-health-poll', slug: 'api-health-poll',
+        token: 'tok_demo_apihealthpoll02', status: 'late', type: 'http',
+        url: 'https://api.example.com/health', periodSeconds: 300, graceSeconds: 120, schedule: null,
+        lastPingAt: iso(40 * 60), nextDueAt: String(now() - 15 * 60), alertAfterAt: String(now() - 10 * 60),
+        lastAlertAt: iso(9 * 60),
+        createdAt: iso(160 * 86400),
+        alertChannels: ['chan-mattermost-1', 'chan-webhook-1'],
+        tags: ['prod', 'api'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 1, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: '"status":"ok"', failureThreshold: 2,
+      },
+      {
+        // Deliberate edge case: LATE with zero alert channels — should show
+        // the amber "alerts disabled" warning on the detail page.
+        checkId: 'check-3', teamId: 'team-sre', name: 'payment-webhook-processor', slug: 'payment-webhook-processor',
+        token: 'tok_demo_paymentwebhook03', status: 'late', type: 'heartbeat',
+        periodSeconds: 900, graceSeconds: 300, schedule: null,
+        lastPingAt: iso(2 * HOUR), nextDueAt: String(now() - 40 * 60), alertAfterAt: String(now() - 35 * 60),
+        lastAlertAt: null,
+        createdAt: iso(30 * 86400),
+        alertChannels: [],
+        tags: ['prod', 'payments'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+      {
+        checkId: 'check-4', teamId: 'team-sre', name: 'cache-warmer', slug: 'cache-warmer',
+        token: 'tok_demo_cachewarmer04', status: 'paused', type: 'heartbeat',
+        periodSeconds: 600, graceSeconds: 180, schedule: null,
+        lastPingAt: iso(3 * 86400), nextDueAt: null, alertAfterAt: null, lastAlertAt: null,
+        createdAt: iso(80 * 86400),
+        alertChannels: ['chan-mattermost-1'],
+        tags: ['staging'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+      {
+        // Never pinged — exercises the onboarding empty state / curl snippet.
+        checkId: 'check-5', teamId: 'team-sre', name: 'etl-hourly-sync', slug: 'etl-hourly-sync',
+        token: 'tok_demo_etlhourlysync05', status: 'pending', type: 'cron', schedule: '0 * * * *',
+        periodSeconds: null, graceSeconds: 600,
+        lastPingAt: null, nextDueAt: String(now() + HOUR), alertAfterAt: String(now() + HOUR + 600), lastAlertAt: null,
+        createdAt: iso(15 * 60),
+        alertChannels: ['chan-email-1'],
+        tags: ['prod', 'etl'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+      {
+        // Currently suppressed — exercises the amber suppression notice.
+        checkId: 'check-6', teamId: 'team-sre', name: 'backup-verification', slug: 'backup-verification',
+        token: 'tok_demo_backupverify06', status: 'up', type: 'cron', schedule: '30 3 * * *',
+        periodSeconds: null, graceSeconds: 1800,
+        lastPingAt: iso(4 * HOUR), nextDueAt: String(now() + 20 * HOUR), alertAfterAt: String(now() + 21 * HOUR),
+        lastAlertAt: iso(2 * 86400),
+        createdAt: iso(200 * 86400),
+        alertChannels: ['chan-mattermost-1'],
+        tags: ['prod', 'db'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: 3, suppressDurationMinutes: 240, consecutiveAlertCount: 3,
+        suppressedUntil: isoFuture(90 * 60),
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+      {
+        checkId: 'check-7', teamId: 'team-sre', name: 'certificate-renewal-check', slug: 'certificate-renewal-check',
+        token: 'tok_demo_certcheck07', status: 'up', type: 'http',
+        url: 'https://example.com/', periodSeconds: 21600, graceSeconds: 1800, schedule: null,
+        lastPingAt: iso(HOUR), nextDueAt: String(now() + 5 * HOUR), alertAfterAt: String(now() + 5 * HOUR + 1800),
+        lastAlertAt: null,
+        createdAt: iso(140 * 86400),
+        alertChannels: ['chan-shared-1'],
+        tags: ['prod', 'security'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+      {
+        checkId: 'check-8', teamId: 'team-sre', name: 'log-shipper', slug: 'log-shipper',
+        token: 'tok_demo_logshipper08', status: 'up', type: 'heartbeat',
+        periodSeconds: 300, graceSeconds: 120, schedule: null,
+        lastPingAt: iso(2 * 60), nextDueAt: String(now() + 3 * 60), alertAfterAt: String(now() + 5 * 60), lastAlertAt: null,
+        createdAt: iso(50 * 86400),
+        alertChannels: ['chan-telegram-1'],
+        tags: ['staging'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+      {
+        // Approaching but not yet late (consecutiveFailureCount < threshold)
+        checkId: 'check-9', teamId: 'team-sre', name: 'webhook-relay', slug: 'webhook-relay',
+        token: 'tok_demo_webhookrelay09', status: 'up', type: 'http',
+        url: 'https://relay.example.com/status', periodSeconds: 120, graceSeconds: 60, schedule: null,
+        lastPingAt: iso(90), nextDueAt: String(now() + 30), alertAfterAt: String(now() + 90), lastAlertAt: null,
+        createdAt: iso(20 * 86400),
+        alertChannels: ['chan-webhook-1', 'chan-mattermost-1'],
+        tags: ['prod'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+        expectedStatusCode: 204, expectedString: null, failureThreshold: 3,
+      },
+      {
+        checkId: 'check-10', teamId: 'team-sre', name: 'staging-smoke-test', slug: 'staging-smoke-test',
+        token: 'tok_demo_stagingsmoke10', status: 'paused', type: 'cron', schedule: '*/15 * * * *',
+        periodSeconds: null, graceSeconds: 300,
+        lastPingAt: iso(5 * 86400), nextDueAt: null, alertAfterAt: null, lastAlertAt: null,
+        createdAt: iso(70 * 86400),
+        alertChannels: [],
+        tags: ['staging', 'qa'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+    ],
+    'team-data': [
+      {
+        checkId: 'check-11', teamId: 'team-data', name: 'spark-job-nightly', slug: 'spark-job-nightly',
+        token: 'tok_demo_sparknightly11', status: 'up', type: 'cron', schedule: '0 1 * * *',
+        periodSeconds: null, graceSeconds: 3600,
+        lastPingAt: iso(9 * HOUR), nextDueAt: String(now() + 15 * HOUR), alertAfterAt: String(now() + 16 * HOUR), lastAlertAt: null,
+        createdAt: iso(100 * 86400),
+        alertChannels: ['chan-data-webhook'],
+        tags: ['prod', 'spark'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+      {
+        checkId: 'check-12', teamId: 'team-data', name: 'airflow-dag-sync', slug: 'airflow-dag-sync',
+        token: 'tok_demo_airflowdag12', status: 'late', type: 'heartbeat',
+        periodSeconds: 1800, graceSeconds: 600, schedule: null,
+        lastPingAt: iso(50 * 60), nextDueAt: String(now() - 5 * 60), alertAfterAt: String(now() - 2 * 60), lastAlertAt: iso(60),
+        createdAt: iso(60 * 86400),
+        alertChannels: ['chan-data-webhook'],
+        tags: ['prod', 'airflow'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 1, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+      {
+        checkId: 'check-13', teamId: 'team-data', name: 'data-quality-check', slug: 'data-quality-check',
+        token: 'tok_demo_dataquality13', status: 'pending', type: 'cron', schedule: '0 6 * * *',
+        periodSeconds: null, graceSeconds: 900,
+        lastPingAt: null, nextDueAt: String(now() + 8 * HOUR), alertAfterAt: String(now() + 8 * HOUR + 900), lastAlertAt: null,
+        createdAt: iso(3 * 3600),
+        alertChannels: [],
+        tags: ['staging'],
+        escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+        suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+        expectedStatusCode: 200, expectedString: null, failureThreshold: 1,
+      },
+    ],
+  },
+
+  // checkId -> pings, newest first. check-2 gets 35 pings to exercise "Load more".
+  pings: buildPings(),
+
+  // checkId -> alert delivery history, newest first
+  alertHistory: buildAlertHistory(),
+
+  auditLog: {
+    'team-sre': buildAuditLog(),
+    'team-data': [
+      { eventId: 'audit-d1', actorId: 'user-demo-2', actorEmail: 'priya@example.com', action: 'check.created', targetType: 'check', targetId: 'check-13', targetName: 'data-quality-check', detail: null, createdAt: iso(3 * 3600) },
+      { eventId: 'audit-d2', actorId: CURRENT_USER.userId, actorEmail: CURRENT_USER.email, action: 'channel.created', targetType: 'channel', targetId: 'chan-data-webhook', targetName: 'Data Eng Webhook', detail: 'type: webhook', createdAt: iso(90 * 86400) },
+    ],
+  },
+
+  maintenanceWindows: {
+    'team-sre': [
+      { windowId: 'maint-1', teamId: 'team-sre', checkId: 'check-1', startAt: isoFuture(2 * 86400), endAt: isoFuture(2 * 86400 + 7200), label: 'Planned DB migration', createdBy: CURRENT_USER.userId, createdAt: iso(86400) },
+      { windowId: 'maint-2', teamId: 'team-sre', checkId: null, startAt: iso(20 * 3600), endAt: iso(19 * 3600), label: 'Datacenter network maintenance (all checks)', createdBy: 'user-demo-2', createdAt: iso(2 * 86400) },
+    ],
+    'team-data': [],
+  },
+
+  reports: {
+    'team-sre': [
+      { reportId: 'report-1', teamId: 'team-sre', checkId: null, reportType: 'summary', format: 'json', from: iso(30 * 86400), to: iso(0), status: 'completed', downloadUrl: '/teams/team-sre/reports/report-1/download', createdAt: iso(2 * 3600), createdBy: CURRENT_USER.userId, expiresAt: isoFuture(5 * 86400), fileName: 'summary-report-report-1.json', contentType: 'application/json' },
+      { reportId: 'report-2', teamId: 'team-sre', checkId: 'check-2', reportType: 'uptime', format: 'csv', from: iso(7 * 86400), to: iso(0), status: 'completed', downloadUrl: '/teams/team-sre/reports/report-2/download', createdAt: iso(25 * 3600), createdBy: 'user-demo-2', expiresAt: iso(-3600), fileName: 'uptime-report-report-2.csv', contentType: 'text/csv' },
+    ],
+    'team-data': [],
+  },
+
+  apiTokens: {
+    'team-sre': [
+      { token_id: 'apitok-1', name: 'CI deploy hook', created_at: iso(60 * 86400), last_used_at: iso(3600), expires_at: null, user_id: CURRENT_USER.userId },
+      { token_id: 'apitok-2', name: 'Temporary migration script', created_at: iso(10 * 86400), last_used_at: iso(9 * 86400), expires_at: isoFuture(2 * 86400), user_id: 'user-demo-2' },
+    ],
+    'team-data': [],
+  },
+}
+
+function buildPings() {
+  const pings = {}
+
+  // check-2 (api-health-poll, LATE): rich history including the failure run
+  const p2 = []
+  for (let i = 0; i < 35; i++) {
+    const agoMinutes = i * 5
+    const isFailureWindow = i < 3 // most recent 3 are the ongoing outage
+    p2.push({
+      checkId: 'check-2',
+      timestamp: String(now() - agoMinutes * 60),
+      receivedAt: iso(agoMinutes * 60),
+      pingType: isFailureWindow ? 'fail' : 'success',
+      code: isFailureWindow ? '503' : null,
+      data: isFailureWindow ? 'Got 503, expected 200' : null,
+      responseTimeMs: isFailureWindow ? 8200 + i * 40 : 90 + Math.round(Math.sin(i) * 30),
+    })
+  }
+  pings['check-2'] = p2
+
+  // check-1 (nightly-db-backup): a handful of clean nightly runs
+  pings['check-1'] = Array.from({ length: 8 }, (_, i) => ({
+    checkId: 'check-1',
+    timestamp: String(now() - (i * 86400 + 6 * 3600)),
+    receivedAt: iso(i * 86400 + 6 * 3600),
+    pingType: 'success',
+    code: null,
+    data: `Backup completed: ${(1.1 + i * 0.03).toFixed(2)}GB`,
+    responseTimeMs: null,
+  }))
+
+  // check-3 (payment-webhook-processor, LATE, no channels)
+  pings['check-3'] = Array.from({ length: 6 }, (_, i) => ({
+    checkId: 'check-3',
+    timestamp: String(now() - (i * 900 + 7200)),
+    receivedAt: iso(i * 900 + 7200),
+    pingType: 'success',
+    code: null,
+    data: null,
+    responseTimeMs: null,
+  }))
+
+  pings['check-9'] = Array.from({ length: 12 }, (_, i) => ({
+    checkId: 'check-9',
+    timestamp: String(now() - i * 120),
+    receivedAt: iso(i * 120),
+    pingType: i === 1 || i === 2 ? 'fail' : 'success',
+    code: i === 1 || i === 2 ? '502' : null,
+    data: i === 1 || i === 2 ? 'Got 502, expected 204' : null,
+    responseTimeMs: i === 1 || i === 2 ? 4100 : 45,
+  }))
+
+  return pings
+}
+
+function buildAlertHistory() {
+  const history = {}
+
+  history['check-2'] = [
+    { deliveryId: 'del-1', checkId: 'check-2', checkName: 'api-health-poll', channelId: 'chan-mattermost-1', channelType: 'mattermost', channelName: 'Platform Oncall (Mattermost)', alertType: 'late', status: 'delivered', attempts: 1, maxAttempts: 5, lastError: null, createdAt: iso(9 * 60), deliveredAt: iso(9 * 60 - 2) },
+    { deliveryId: 'del-2', checkId: 'check-2', checkName: 'api-health-poll', channelId: 'chan-webhook-1', channelType: 'webhook', channelName: 'PagerDuty Bridge', alertType: 'late', status: 'pending', attempts: 2, maxAttempts: 5, lastError: 'Connection timeout after 10s', createdAt: iso(9 * 60), deliveredAt: null },
+  ]
+  history['check-3'] = [] // no channels configured — nothing was ever attempted
+  history['check-6'] = [
+    { deliveryId: 'del-3', checkId: 'check-6', checkName: 'backup-verification', channelId: 'chan-mattermost-1', channelType: 'mattermost', channelName: 'Platform Oncall (Mattermost)', alertType: 'late', status: 'failed', attempts: 5, maxAttempts: 5, lastError: 'Mattermost returned HTTP 410 (webhook removed)', createdAt: iso(2 * 86400), deliveredAt: null },
+    { deliveryId: 'del-4', checkId: 'check-6', checkName: 'backup-verification', channelId: 'chan-mattermost-1', channelType: 'mattermost', channelName: 'Platform Oncall (Mattermost)', alertType: 'late', status: 'delivered', attempts: 1, maxAttempts: 5, lastError: null, createdAt: iso(3 * 86400), deliveredAt: iso(3 * 86400 - 3) },
+    { deliveryId: 'del-5', checkId: 'check-6', checkName: 'backup-verification', channelId: 'chan-mattermost-1', channelType: 'mattermost', channelName: 'Platform Oncall (Mattermost)', alertType: 'recovery', status: 'delivered', attempts: 1, maxAttempts: 5, lastError: null, createdAt: iso(3 * 86400 - 1800), deliveredAt: iso(3 * 86400 - 1802) },
+  ]
+  history['check-12'] = [
+    { deliveryId: 'del-6', checkId: 'check-12', checkName: 'airflow-dag-sync', channelId: 'chan-data-webhook', channelType: 'webhook', channelName: 'Data Eng Webhook', alertType: 'late', status: 'delivered', attempts: 1, maxAttempts: 5, lastError: null, createdAt: iso(60), deliveredAt: iso(58) },
+  ]
+
+  return history
+}
+
+function buildAuditLog() {
+  const actors = [
+    { id: CURRENT_USER.userId, email: CURRENT_USER.email },
+    { id: 'user-demo-2', email: 'priya@example.com' },
+    { id: 'user-demo-3', email: 'marcus@example.com' },
+  ]
+  const entries = [
+    ['check.created', 'check', 'check-9', 'webhook-relay', null, 20 * 86400],
+    ['channel.created', 'channel', 'chan-telegram-1', 'Mobile Alerts', 'type: telegram', 60 * 86400],
+    ['check.paused', 'check', 'check-10', 'staging-smoke-test', null, 15 * 86400],
+    ['member.role_changed', 'member', 'user-demo-3', null, 'new role: member', 10 * 86400],
+    ['check.token_rotated', 'check', 'check-4', 'cache-warmer', null, 8 * 86400],
+    ['channel.deleted', 'channel', 'chan-legacy-slack', 'Legacy Slack (removed)', 'type: webhook', 6 * 86400],
+    ['member.invited', 'member', 'new-hire@example.com', 'new-hire@example.com', 'role: member', 2 * 86400],
+    ['check.updated', 'check', 'check-6', 'backup-verification', 'changed: suppressAfterCount, suppressDurationMinutes', 40 * 3600],
+    ['check.escalated', 'check', 'check-2', 'api-health-poll', null, 9 * 60],
+    ['token.created', 'token', 'apitok-2', 'Temporary migration script', null, 10 * 86400],
+  ]
+  return entries.map(([action, targetType, targetId, targetName, detail, secondsAgo], i) => ({
+    eventId: `audit-${i + 1}`,
+    actorId: actors[i % actors.length].id,
+    actorEmail: actors[i % actors.length].email,
+    action, targetType, targetId, targetName, detail,
+    createdAt: iso(secondsAgo),
+  }))
+}
+
+export function findUser(userId) {
+  if (userId === CURRENT_USER.userId) return CURRENT_USER
+  return OTHER_USERS.find((u) => u.userId === userId) || null
+}

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -1,0 +1,516 @@
+// Local mock backend for UX/design review sessions — NOT used in production
+// or automated tests. Runs as a Vite dev-server middleware (same origin,
+// same port as the frontend), so `npm run dev:mock` is the only command
+// needed. See frontend/mock/README.md.
+import { randomUUID } from 'node:crypto'
+import { state, CURRENT_USER, findUser } from './data.js'
+
+const ARTIFICIAL_DELAY_MS = 200 // makes loading states visible for design review
+
+// ---------------------------------------------------------------------------
+// Tiny router: routes are tried in registration order, so register more
+// specific literal paths (…/checks/bulk/pause) before the generic
+// param-based ones they'd otherwise collide with (…/checks/:checkId/pause).
+// ---------------------------------------------------------------------------
+const routes = []
+
+function route(method, pattern, handler) {
+  const paramNames = []
+  const regexSource = pattern
+    .split('/')
+    .map((segment) => {
+      if (segment.startsWith(':')) {
+        paramNames.push(segment.slice(1))
+        return '([^/]+)'
+      }
+      return segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    })
+    .join('/')
+  const regex = new RegExp(`^${regexSource}$`)
+  routes.push({ method, regex, paramNames, handler })
+}
+
+function match(method, pathname) {
+  for (const r of routes) {
+    if (r.method !== method) continue
+    const m = r.regex.exec(pathname)
+    if (!m) continue
+    const params = {}
+    r.paramNames.forEach((name, i) => { params[name] = decodeURIComponent(m[i + 1]) })
+    return { handler: r.handler, params }
+  }
+  return null
+}
+
+class HttpError extends Error {
+  constructor(status, message) {
+    super(message)
+    this.status = status
+  }
+}
+
+function notFound(what = 'Resource') {
+  return new HttpError(404, `${what} not found`)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers over the seed data
+// ---------------------------------------------------------------------------
+function teamRole(teamId) {
+  return state.membership[teamId] || null
+}
+
+function requireTeam(teamId) {
+  const team = state.teams.find((t) => t.teamId === teamId)
+  if (!team) throw notFound('Team')
+  return team
+}
+
+function requireCheck(teamId, checkId) {
+  const check = (state.checks[teamId] || []).find((c) => c.checkId === checkId)
+  if (!check) throw notFound('Check')
+  return check
+}
+
+function checksList(teamId) {
+  return state.checks[teamId] || []
+}
+
+function aggregateStats(pings) {
+  const successCount = pings.filter((p) => p.pingType === 'success').length
+  const failCount = pings.filter((p) => p.pingType === 'fail').length
+  const totalPings = successCount + failCount
+  const samples = pings.filter((p) => p.responseTimeMs != null).map((p) => p.responseTimeMs)
+  const sorted = [...samples].sort((a, b) => a - b)
+  const pct = (p) => (sorted.length ? sorted[Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1)] : null)
+  const series = [...pings].reverse().filter((p) => p.responseTimeMs != null).map((p) => ({
+    timestamp: p.receivedAt, responseTimeMs: p.responseTimeMs, pingType: p.pingType,
+  }))
+  return {
+    uptimePct: totalPings ? Math.round((successCount / totalPings) * 10000) / 100 : 0,
+    totalPings, successCount, failCount,
+    avgResponseMs: samples.length ? Math.round(samples.reduce((a, b) => a + b, 0) / samples.length) : null,
+    p95ResponseMs: pct(95),
+    maxResponseMs: sorted.length ? sorted[sorted.length - 1] : null,
+    minResponseMs: sorted.length ? sorted[0] : null,
+    latestResponseMs: series.length ? series[series.length - 1].responseTimeMs : null,
+    responseTimeSeries: series,
+  }
+}
+
+function aggregateErrors(pings) {
+  const failures = pings.filter((p) => p.pingType === 'fail')
+  const codeCounts = {}
+  for (const f of failures) {
+    const code = f.code || 'unknown'
+    codeCounts[code] = (codeCounts[code] || 0) + 1
+  }
+  const failureCodes = Object.entries(codeCounts).map(([code, count]) => ({ code, count }))
+  const mostCommon = failureCodes.sort((a, b) => b.count - a.count)[0]
+  return {
+    totalFailures: failures.length,
+    mostCommonCode: mostCommon ? mostCommon.code : null,
+    lastFailureAt: failures.length ? failures[0].receivedAt : null,
+    longestIncident: failures.length ? {
+      startedAt: failures[failures.length - 1].receivedAt,
+      endedAt: failures[0].receivedAt,
+      durationSeconds: 900,
+      failureCount: failures.length,
+      dominantCode: mostCommon ? mostCommon.code : 'unknown',
+    } : null,
+    failureCodes,
+    recentFailures: failures.slice(0, 10),
+  }
+}
+
+function aggregateUptime(check, excludeMaintenance) {
+  const pings = state.pings[check.checkId] || []
+  const stats = aggregateStats(pings)
+  const downtimeMinutes = stats.failCount * 5
+  return {
+    from: new Date(Date.now() - 7 * 86400000).toISOString(),
+    to: new Date().toISOString(),
+    excludeMaintenance,
+    uptimePct: stats.uptimePct,
+    totalObservedMinutes: 7 * 24 * 60,
+    downtimeMinutes,
+    excludedMaintenanceMinutes: excludeMaintenance ? 60 : 0,
+    incidents: stats.failCount ? [{
+      startedAt: pings.find((p) => p.pingType === 'fail')?.receivedAt || new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      durationSeconds: downtimeMinutes * 60,
+      failureCount: stats.failCount,
+      dominantCode: '503',
+    }] : [],
+    maintenanceWindows: state.maintenanceWindows[check.teamId] || [],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+route('GET', '/me', () => CURRENT_USER)
+
+route('POST', '/teams', (_p, body) => {
+  const teamId = `team-${randomUUID().slice(0, 8)}`
+  const team = { teamId, name: body.name, slug: body.name.toLowerCase().replace(/[^a-z0-9]+/g, '-'), createdAt: new Date().toISOString(), createdBy: CURRENT_USER.userId }
+  state.teams.push(team)
+  state.membership[teamId] = 'admin'
+  state.checks[teamId] = []
+  state.channels[teamId] = []
+  state.members[teamId] = [{ userId: CURRENT_USER.userId, email: CURRENT_USER.email, name: CURRENT_USER.name, role: 'admin', joinedAt: team.createdAt, status: 'active' }]
+  state.auditLog[teamId] = []
+  state.maintenanceWindows[teamId] = []
+  state.reports[teamId] = []
+  state.apiTokens[teamId] = []
+  return { ...team, role: 'admin' }
+})
+
+route('GET', '/teams', () => state.teams
+  .filter((t) => teamRole(t.teamId))
+  .map((t) => ({ teamId: t.teamId, name: t.name, slug: t.slug, role: teamRole(t.teamId), createdAt: t.createdAt })))
+
+route('GET', '/teams/:teamId', ({ teamId }) => {
+  const team = requireTeam(teamId)
+  return { teamId: team.teamId, name: team.name, slug: team.slug, createdAt: team.createdAt, createdBy: team.createdBy }
+})
+
+route('PATCH', '/teams/:teamId', ({ teamId }, body) => {
+  const team = requireTeam(teamId)
+  if (body.name) team.name = body.name
+  return team
+})
+
+route('DELETE', '/teams/:teamId', ({ teamId }) => {
+  state.teams = state.teams.filter((t) => t.teamId !== teamId)
+  delete state.membership[teamId]
+  return { message: 'Team deleted' }
+})
+
+// --- Checks -----------------------------------------------------------------
+
+route('GET', '/teams/:teamId/checks', ({ teamId }) => checksList(teamId))
+
+route('POST', '/teams/:teamId/checks', ({ teamId }, body) => {
+  requireTeam(teamId)
+  const checkId = `check-${randomUUID().slice(0, 8)}`
+  const check = {
+    checkId, teamId, name: body.name, slug: body.name.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+    token: `tok_${randomUUID().replace(/-/g, '')}`,
+    status: 'pending', type: body.type || 'heartbeat',
+    schedule: body.schedule || null, periodSeconds: body.periodSeconds || null, graceSeconds: body.graceSeconds ?? 300,
+    lastPingAt: null, nextDueAt: null, alertAfterAt: null, lastAlertAt: null,
+    createdAt: new Date().toISOString(),
+    alertChannels: body.alertChannels || [], tags: body.tags || [],
+    escalationMinutes: null, escalationAlertChannels: [], escalationTriggeredAt: null,
+    suppressAfterCount: null, suppressDurationMinutes: null, consecutiveAlertCount: 0, suppressedUntil: null,
+    url: body.url || null, expectedStatusCode: body.expectedStatusCode ?? 200,
+    expectedString: body.expectedString || null, failureThreshold: body.failureThreshold ?? 1,
+  }
+  state.checks[teamId] = state.checks[teamId] || []
+  state.checks[teamId].push(check)
+  state.pings[checkId] = []
+  state.alertHistory[checkId] = []
+  return check
+})
+
+route('POST', '/teams/:teamId/checks/bulk/pause', ({ teamId }, body) => {
+  for (const id of body.check_ids || []) {
+    const c = checksList(teamId).find((c) => c.checkId === id)
+    if (c) c.status = 'paused'
+  }
+  return { message: `${(body.check_ids || []).length} check(s) paused` }
+})
+
+route('POST', '/teams/:teamId/checks/bulk/resume', ({ teamId }, body) => {
+  for (const id of body.check_ids || []) {
+    const c = checksList(teamId).find((c) => c.checkId === id)
+    if (c) c.status = 'up'
+  }
+  return { message: `${(body.check_ids || []).length} check(s) resumed` }
+})
+
+route('GET', '/teams/:teamId/checks/:checkId', ({ teamId, checkId }) => requireCheck(teamId, checkId))
+
+route('PATCH', '/teams/:teamId/checks/:checkId', ({ teamId, checkId }, body) => {
+  const check = requireCheck(teamId, checkId)
+  Object.assign(check, body)
+  return check
+})
+
+route('POST', '/teams/:teamId/checks/:checkId/pause', ({ teamId, checkId }) => {
+  requireCheck(teamId, checkId).status = 'paused'
+  return { message: 'Check paused' }
+})
+
+route('POST', '/teams/:teamId/checks/:checkId/resume', ({ teamId, checkId }) => {
+  requireCheck(teamId, checkId).status = 'up'
+  return { message: 'Check resumed' }
+})
+
+route('POST', '/teams/:teamId/checks/:checkId/rotate-token', ({ teamId, checkId }) => {
+  const check = requireCheck(teamId, checkId)
+  check.token = `tok_${randomUUID().replace(/-/g, '')}`
+  return check
+})
+
+route('POST', '/teams/:teamId/checks/:checkId/escalate', ({ teamId, checkId }) => {
+  requireCheck(teamId, checkId).escalationTriggeredAt = new Date().toISOString()
+  return { message: 'Escalation triggered successfully' }
+})
+
+route('POST', '/teams/:teamId/checks/:checkId/suppress', ({ teamId, checkId }) => {
+  const check = requireCheck(teamId, checkId)
+  check.suppressedUntil = new Date(Date.now() + (check.suppressDurationMinutes || 60) * 60000).toISOString()
+  return { message: `Alerts suppressed for ${check.suppressDurationMinutes || 60} minutes` }
+})
+
+route('DELETE', '/teams/:teamId/checks/:checkId', ({ teamId, checkId }) => {
+  state.checks[teamId] = checksList(teamId).filter((c) => c.checkId !== checkId)
+  return { message: 'Check deleted successfully' }
+})
+
+route('GET', '/teams/:teamId/checks/:checkId/pings', ({ teamId, checkId }, _body, query) => {
+  requireCheck(teamId, checkId)
+  const limit = parseInt(query.get('limit') || '20', 10)
+  return (state.pings[checkId] || []).slice(0, limit)
+})
+
+route('GET', '/teams/:teamId/checks/:checkId/stats', ({ teamId, checkId }, _body, query) => {
+  requireCheck(teamId, checkId)
+  return { period: query.get('range') || '24h', ...aggregateStats(state.pings[checkId] || []) }
+})
+
+route('GET', '/teams/:teamId/checks/:checkId/errors/summary', ({ teamId, checkId }, _body, query) => {
+  requireCheck(teamId, checkId)
+  return { period: query.get('range') || '24h', ...aggregateErrors(state.pings[checkId] || []) }
+})
+
+route('GET', '/teams/:teamId/checks/:checkId/uptime', ({ teamId, checkId }, _body, query) => {
+  const check = requireCheck(teamId, checkId)
+  return aggregateUptime(check, query.get('exclude_maintenance') !== 'false')
+})
+
+route('GET', '/teams/:teamId/checks/:checkId/alert-history', ({ teamId, checkId }, _body, query) => {
+  requireCheck(teamId, checkId)
+  const limit = parseInt(query.get('limit') || '50', 10)
+  return (state.alertHistory[checkId] || []).slice(0, limit)
+})
+
+// --- Audit --------------------------------------------------------------
+
+route('GET', '/teams/:teamId/audit', ({ teamId }, _body, query) => {
+  const limit = parseInt(query.get('limit') || '100', 10)
+  return (state.auditLog[teamId] || []).slice(0, limit)
+})
+
+// --- Maintenance windows --------------------------------------------------
+
+route('GET', '/teams/:teamId/maintenance', ({ teamId }, _body, query) => {
+  const checkId = query.get('check_id')
+  const windows = state.maintenanceWindows[teamId] || []
+  return checkId ? windows.filter((w) => !w.checkId || w.checkId === checkId) : windows
+})
+
+route('POST', '/teams/:teamId/maintenance', ({ teamId }, body) => {
+  const window = {
+    windowId: `maint-${randomUUID().slice(0, 8)}`, teamId,
+    checkId: body.checkId || body.check_id || null,
+    startAt: body.startAt || body.start_at, endAt: body.endAt || body.end_at,
+    label: body.label || null, createdBy: CURRENT_USER.userId, createdAt: new Date().toISOString(),
+  }
+  state.maintenanceWindows[teamId] = state.maintenanceWindows[teamId] || []
+  state.maintenanceWindows[teamId].push(window)
+  return window
+})
+
+route('DELETE', '/teams/:teamId/maintenance/:windowId', ({ teamId, windowId }) => {
+  state.maintenanceWindows[teamId] = (state.maintenanceWindows[teamId] || []).filter((w) => w.windowId !== windowId)
+  return { message: 'Maintenance window deleted' }
+})
+
+// --- Reports ---------------------------------------------------------------
+
+route('POST', '/teams/:teamId/reports', ({ teamId }, body) => {
+  const reportId = `report-${randomUUID().slice(0, 8)}`
+  const report = {
+    reportId, teamId, checkId: body.checkId || null, reportType: body.reportType, format: body.format,
+    from: body.from, to: body.to, status: 'completed',
+    downloadUrl: `/teams/${teamId}/reports/${reportId}/download`,
+    createdAt: new Date().toISOString(), createdBy: CURRENT_USER.userId,
+    expiresAt: new Date(Date.now() + 7 * 86400000).toISOString(),
+    fileName: `${body.reportType}-report-${reportId}.${body.format}`, contentType: body.format === 'csv' ? 'text/csv' : 'application/json',
+  }
+  state.reports[teamId] = state.reports[teamId] || []
+  state.reports[teamId].push(report)
+  return report
+})
+
+route('GET', '/teams/:teamId/reports', ({ teamId }) => state.reports[teamId] || [])
+
+route('GET', '/teams/:teamId/reports/:reportId', ({ teamId, reportId }) => {
+  const report = (state.reports[teamId] || []).find((r) => r.reportId === reportId)
+  if (!report) throw notFound('Report')
+  return report
+})
+
+route('DELETE', '/teams/:teamId/reports/:reportId', ({ teamId, reportId }) => {
+  state.reports[teamId] = (state.reports[teamId] || []).filter((r) => r.reportId !== reportId)
+  return { message: 'Report deleted' }
+})
+
+route('GET', '/teams/:teamId/reports/:reportId/download', ({ teamId, reportId }) => {
+  const report = (state.reports[teamId] || []).find((r) => r.reportId === reportId)
+  if (!report) throw notFound('Report')
+  const body = report.contentType === 'text/csv'
+    ? 'check_id,check_name,status\ncheck-2,api-health-poll,late\n'
+    : JSON.stringify({ teamId, reportType: report.reportType, generatedAt: report.createdAt }, null, 2)
+  return { __raw: true, body, contentType: report.contentType, fileName: report.fileName }
+})
+
+// --- Members / invitations --------------------------------------------------
+
+route('GET', '/teams/:teamId/members', ({ teamId }) => state.members[teamId] || [])
+
+route('POST', '/teams/:teamId/members', ({ teamId }, body) => {
+  state.members[teamId] = state.members[teamId] || []
+  state.members[teamId].push({ userId: null, email: body.email, name: 'Pending User', role: body.role || 'member', joinedAt: new Date().toISOString(), status: 'pending' })
+  return { message: `Invitation sent to ${body.email}` }
+})
+
+route('DELETE', '/teams/:teamId/members/:userId', ({ teamId, userId }) => {
+  state.members[teamId] = (state.members[teamId] || []).filter((m) => m.userId !== userId)
+  return { message: 'Member removed successfully' }
+})
+
+route('PATCH', '/teams/:teamId/members/:userId', ({ teamId, userId }, body) => {
+  const member = (state.members[teamId] || []).find((m) => m.userId === userId)
+  if (member) member.role = body.role
+  return { message: 'Member role updated successfully' }
+})
+
+route('DELETE', '/teams/:teamId/invitations/:email', ({ teamId, email }) => {
+  state.members[teamId] = (state.members[teamId] || []).filter((m) => m.email !== email)
+  return { message: 'Invitation deleted' }
+})
+
+// --- Alert channels ----------------------------------------------------------
+
+route('GET', '/teams/:teamId/channels', ({ teamId }) => state.channels[teamId] || [])
+
+route('POST', '/teams/:teamId/channels', ({ teamId }, body) => {
+  const channel = {
+    channelId: `chan-${randomUUID().slice(0, 8)}`, teamId,
+    name: body.name, displayName: body.displayName, type: body.type,
+    configuration: body.configuration || {}, shared: !!body.shared,
+    createdAt: new Date().toISOString(), createdBy: CURRENT_USER.userId,
+  }
+  state.channels[teamId] = state.channels[teamId] || []
+  state.channels[teamId].push(channel)
+  return channel
+})
+
+route('GET', '/teams/:teamId/channels/:channelId', ({ teamId, channelId }) => {
+  const channel = (state.channels[teamId] || []).find((c) => c.channelId === channelId)
+  if (!channel) throw notFound('Alert channel')
+  return channel
+})
+
+route('PATCH', '/teams/:teamId/channels/:channelId', ({ teamId, channelId }, body) => {
+  const channel = (state.channels[teamId] || []).find((c) => c.channelId === channelId)
+  if (!channel) throw notFound('Alert channel')
+  if (body.displayName) channel.displayName = body.displayName
+  if (body.configuration) channel.configuration = body.configuration
+  if (typeof body.shared === 'boolean') channel.shared = body.shared
+  return channel
+})
+
+route('DELETE', '/teams/:teamId/channels/:channelId', ({ teamId, channelId }) => {
+  state.channels[teamId] = (state.channels[teamId] || []).filter((c) => c.channelId !== channelId)
+  return { message: 'Alert channel deleted successfully' }
+})
+
+route('POST', '/teams/:teamId/channels/:channelId/test', () => ({ message: 'Test notification sent successfully' }))
+
+// --- API tokens ---------------------------------------------------------
+
+route('GET', '/teams/:teamId/api-tokens', ({ teamId }) => state.apiTokens[teamId] || [])
+
+route('POST', '/teams/:teamId/api-tokens', ({ teamId }, body) => {
+  const token = {
+    token_id: `apitok-${randomUUID().slice(0, 8)}`, name: body.name,
+    created_at: new Date().toISOString(), last_used_at: null, expires_at: body.expires_at || null,
+    user_id: CURRENT_USER.userId,
+  }
+  state.apiTokens[teamId] = state.apiTokens[teamId] || []
+  state.apiTokens[teamId].push(token)
+  return { ...token, token: `pc_${randomUUID().replace(/-/g, '')}` }
+})
+
+route('DELETE', '/teams/:teamId/api-tokens/:tokenId', ({ teamId, tokenId }) => {
+  state.apiTokens[teamId] = (state.apiTokens[teamId] || []).filter((t) => t.token_id !== tokenId)
+  return { deleted: true, token_id: tokenId }
+})
+
+// ---------------------------------------------------------------------------
+// Vite plugin
+// ---------------------------------------------------------------------------
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf-8')
+      if (!raw) return resolve({})
+      try {
+        resolve(JSON.parse(raw))
+      } catch (e) {
+        reject(new HttpError(400, 'Invalid JSON body'))
+      }
+    })
+    req.on('error', reject)
+  })
+}
+
+export function mockApiPlugin() {
+  return {
+    name: 'pulsechecks-mock-api',
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        // Let real page navigations (full loads/refreshes) fall through to
+        // Vite's SPA handling instead of being treated as API calls — some
+        // page routes and API routes share the same /teams/:id/... shape.
+        if ((req.headers.accept || '').includes('text/html')) return next()
+
+        const url = new URL(req.url, 'http://localhost')
+        const found = match(req.method, url.pathname)
+        if (!found) return next()
+
+        try {
+          const body = ['POST', 'PATCH', 'PUT', 'DELETE'].includes(req.method) ? await readBody(req) : {}
+          if (ARTIFICIAL_DELAY_MS) await new Promise((r) => setTimeout(r, ARTIFICIAL_DELAY_MS))
+          const result = found.handler(found.params, body, url.searchParams)
+
+          if (result && result.__raw) {
+            res.statusCode = 200
+            res.setHeader('Content-Type', result.contentType)
+            res.setHeader('Content-Disposition', `attachment; filename="${result.fileName}"`)
+            res.end(result.body)
+            return
+          }
+
+          res.statusCode = 200
+          res.setHeader('Content-Type', 'application/json')
+          res.end(JSON.stringify(result ?? null))
+        } catch (err) {
+          const status = err instanceof HttpError ? err.status : 500
+          res.statusCode = status
+          res.setHeader('Content-Type', 'application/json')
+          res.end(JSON.stringify({ error: err.message || 'Mock server error' }))
+          if (status === 500) console.error('[mock-api]', err)
+        }
+      })
+      console.log('\n  \x1b[35m➜\x1b[0m  \x1b[1mMock API active\x1b[0m — serving fixture data, no backend required\n')
+    },
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:mock": "vite --mode mock",
     "build": "vite build",
     "build:aws": "VITE_CLOUD_PROVIDER=aws vite build",
     "build:gcp": "VITE_CLOUD_PROVIDER=gcp vite build",

--- a/frontend/src/pages/ChecksPage.jsx
+++ b/frontend/src/pages/ChecksPage.jsx
@@ -869,7 +869,7 @@ export default function ChecksPage({ user, onLogout }) {
                     <div className="mt-2 sm:flex sm:justify-between">
                       <div className="sm:flex space-x-4">
                         <p className="flex items-center text-sm text-gray-500">
-                          Period: {formatDuration(check.periodSeconds)}
+                          {check.type === 'cron' ? `Schedule: ${check.schedule}` : `Period: ${formatDuration(check.periodSeconds)}`}
                         </p>
                         <p className="flex items-center text-sm text-gray-500">
                           Grace: {formatDuration(check.graceSeconds)}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,12 +1,23 @@
-import { Activity } from 'lucide-react'
+import { Activity, Wand2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { login, handleCallback } from '../lib/auth'
+import { login, handleCallback, setTokens } from '../lib/auth'
 import { config } from '../config'
+
+const isMock = import.meta.env.VITE_MOCK === 'true'
 
 export default function LoginPage({ onLogin = () => {} }) {
   const navigate = useNavigate()
   const [loginError, setLoginError] = useState(null)
+
+  function handleMockSignIn() {
+    // Design-sandbox only (VITE_MOCK=true): skip real OAuth entirely and
+    // hand the mock API server a token it will accept unconditionally.
+    const tokens = { id_token: 'mock-token', access_token: 'mock-token' }
+    setTokens(tokens)
+    onLogin(tokens)
+    navigate('/', { replace: true })
+  }
 
   async function handleSignIn() {
     setLoginError(null)
@@ -58,12 +69,22 @@ export default function LoginPage({ onLogin = () => {} }) {
         </div>
         
         <div className="mt-8 space-y-6">
-          <button
-            onClick={handleSignIn}
-            className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-          >
-            Sign in with Google Workspace
-          </button>
+          {isMock ? (
+            <button
+              onClick={handleMockSignIn}
+              className="group relative w-full flex justify-center items-center py-3 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500"
+            >
+              <Wand2 className="h-4 w-4 mr-2" />
+              Continue with demo data
+            </button>
+          ) : (
+            <button
+              onClick={handleSignIn}
+              className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              Sign in with Google Workspace
+            </button>
+          )}
 
           {loginError && (
             <div className="bg-red-50 border border-red-200 rounded-md p-3 text-sm text-red-700">
@@ -72,8 +93,14 @@ export default function LoginPage({ onLogin = () => {} }) {
           )}
           
           <div className="text-center text-xs text-gray-500">
-            <p>Secure authentication via Google Workspace SSO</p>
-            <p className="mt-1">Domain-restricted access</p>
+            {isMock ? (
+              <p>Design sandbox — fixture data, nothing here is real or saved anywhere</p>
+            ) : (
+              <>
+                <p>Secure authentication via Google Workspace SSO</p>
+                <p className="mt-1">Domain-restricted access</p>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,9 +1,21 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3000,
-  },
+// `npm run dev:mock` (mode "mock") adds an in-process fake backend so the
+// whole app runs with realistic fixture data and no cloud/auth setup —
+// see mock/README.md. Never included in `npm run build`.
+export default defineConfig(async ({ mode }) => {
+  const plugins = [react()]
+
+  if (mode === 'mock') {
+    const { mockApiPlugin } = await import('./mock/server.js')
+    plugins.push(mockApiPlugin())
+  }
+
+  return {
+    plugins,
+    server: {
+      port: 3000,
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- Adds `npm run dev:mock`: a Vite-mode-gated, in-process fake backend (`frontend/mock/server.js`) plus a realistic fixture dataset (`frontend/mock/data.js`) covering every check/alert/team state the UI can be in (up, late, pending, paused, suppressed, zero-channel, escalation, near-miss thresholds, dead-lettered alerts, pending invitations, etc.)
- Runs same-origin with the frontend (no CORS, no second process), gated entirely behind `mode === 'mock'` / `VITE_MOCK === 'true'` — nothing here is included in `npm run build`, `build:aws`, or `build:gcp`
- Adds a "Continue with demo data" button on the login page (mock mode only) that writes a fake token to `localStorage` and skips real OAuth entirely; no auth code was modified
- Fixes a real bug surfaced while building the sandbox: cron-type checks rendered the literal text "Period: nulls" on the checks list page, because `formatDuration(null)` coerces `null` to `0` instead of short-circuiting. The list row now shows the cron schedule for cron-type checks instead of a bogus duration.

## How to use it
```bash
cd frontend
npm install
npm run dev:mock
```
Open `http://localhost:3000`, click "Continue with demo data". See `frontend/mock/README.md` for details and how to edit the fixtures.

## Known follow-up (not fixed here, flagged for a future pass)
`CheckDetailPage.jsx` has the same unconditional `formatDuration(check.periodSeconds)` call for cron checks, and has no schedule display/edit UI for cron checks at all — the "Edit" affordance would currently render `NaN` in the duration input. This needs a small UI addition (schedule display + validated cron-expression edit form), which is out of scope for this PR.

## Test plan
- [x] `npx vitest run` — all existing frontend tests pass (`64 passed | 1 skipped`), no regressions from the `ChecksPage.jsx` fix
- [x] Verified the full mock sandbox end-to-end via a real Playwright/Chromium browser session: login, dashboard fleet status, checks list (including the cron-schedule fix), check detail, zero-channel warning state
- [x] Verified via curl that all mocked endpoints, pagination, and stateful mutations work as expected
- [x] Confirmed `npm run build` / `build:aws` / `build:gcp` do not include any mock code (mode-gated at the Vite config level)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EKFs8oVHgrjFbrTC4YiBgi)_